### PR TITLE
feat: 여행(Trip) 생성 및 CRUD 기능 구현

### DIFF
--- a/api/src/main/java/com/packit/api/domain/trip/controller/TripController.java
+++ b/api/src/main/java/com/packit/api/domain/trip/controller/TripController.java
@@ -1,0 +1,76 @@
+package com.packit.api.domain.trip.controller;
+
+import com.packit.api.common.security.util.SecurityUtils;
+import com.packit.api.domain.trip.dto.request.TripCreateRequest;
+import com.packit.api.domain.trip.dto.request.TripUpdateRequest;
+import com.packit.api.domain.trip.dto.response.TripResponse;
+import com.packit.api.domain.trip.service.TripService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.file.attribute.UserPrincipal;
+import java.util.List;
+
+@Tag(name = "Trip", description = "여행 생성 및 관리 API")
+@RestController
+@RequestMapping("/api/trips")
+@RequiredArgsConstructor
+public class TripController {
+
+    private final TripService tripService;
+
+    @Operation(
+            summary = "여행 생성",
+            description = "여행 제목, 지역, 시작일/종료일, 유형, 설명을 입력받아 새로운 여행을 생성합니다."
+    )
+    @PostMapping
+    public ResponseEntity<TripResponse> createTrip(
+            @RequestBody @Valid TripCreateRequest request) {
+        TripResponse response = tripService.createTrip(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "내 여행 목록 조회", description = "로그인한 사용자의 전체 여행 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<List<TripResponse>> getTripList() {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(tripService.getTripList(userId));
+    }
+
+    @Operation(summary = "여행 상세 조회", description = "여행 ID에 해당하는 상세 정보를 조회합니다.")
+    @Parameter(name = "id", description = "조회할 여행 ID", required = true)
+    @GetMapping("/{id}")
+    public ResponseEntity<TripResponse> getTripDetail(@PathVariable Long id) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(tripService.getTripDetail(id, userId));
+    }
+
+    @Operation(summary = "여행 수정", description = "여행 ID에 해당하는 여행 정보를 수정합니다.")
+    @Parameters({
+            @Parameter(name = "id", description = "수정할 여행 ID", required = true),
+            @Parameter(name = "request", description = "수정할 여행 정보", required = true)
+    })
+    @PatchMapping("/{id}")
+    public ResponseEntity<TripResponse> updateTrip(
+            @PathVariable Long id,
+            @RequestBody @Valid TripUpdateRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(tripService.updateTrip(id, userId, request));
+    }
+
+    @Operation(summary = "여행 삭제", description = "여행 ID에 해당하는 여행을 삭제합니다.")
+    @Parameter(name = "id", description = "삭제할 여행 ID", required = true)
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTrip(@PathVariable Long id) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        tripService.deleteTrip(id, userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/trip/dto/request/TripCreateRequest.java
+++ b/api/src/main/java/com/packit/api/domain/trip/dto/request/TripCreateRequest.java
@@ -1,0 +1,28 @@
+package com.packit.api.domain.trip.dto.request;
+
+import com.packit.api.domain.trip.entity.TripType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+@Schema(description = "여행 생성 요청 DTO")
+public record TripCreateRequest(
+
+        @Schema(description = "여행 제목", example = "제주도 가족 여행")
+        String title,
+
+        @Schema(description = "여행 지역", example = "제주도")
+        String region,
+
+        @Schema(description = "여행 유형 (FAMILY, FRIEND, BUSINESS, OTHER)", example = "FAMILY")
+        TripType tripType,
+
+        @Schema(description = "여행 시작일 (yyyy-MM-dd)", example = "2025-07-01")
+        LocalDate startDate,
+
+        @Schema(description = "여행 종료일 (yyyy-MM-dd)", example = "2025-07-07")
+        LocalDate endDate,
+
+        @Schema(description = "여행 설명 (선택)", example = "6박 7일 동안 가족과 함께하는 여행입니다.")
+        String description
+) {}

--- a/api/src/main/java/com/packit/api/domain/trip/dto/request/TripUpdateRequest.java
+++ b/api/src/main/java/com/packit/api/domain/trip/dto/request/TripUpdateRequest.java
@@ -1,0 +1,33 @@
+package com.packit.api.domain.trip.dto.request;
+
+import com.packit.api.domain.trip.entity.TripType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record TripUpdateRequest(
+        @NotBlank
+        @Schema(description = "수정할 여행 제목", example = "제주도 가족 여행 - 일정 변경")
+        String title,
+
+        @NotBlank
+        @Schema(description = "여행 지역", example = "제주도")
+        String region,
+
+        @NotNull
+        @Schema(description = "여행 유형 (FAMILY, FRIEND, BUSINESS, OTHER)", example = "FAMILY")
+        TripType tripType,
+
+        @NotNull
+        @Schema(description = "수정된 여행 시작일 (yyyy-MM-dd)", example = "2025-07-02")
+        LocalDate startDate,
+
+        @NotNull
+        @Schema(description = "수정된 여행 종료일 (yyyy-MM-dd)", example = "2025-07-08")
+        LocalDate endDate,
+
+        @Schema(description = "여행 설명 (선택)", example = "일정 변경으로 1일 뒤로 조정됨")
+        String description
+) {}

--- a/api/src/main/java/com/packit/api/domain/trip/dto/response/TripResponse.java
+++ b/api/src/main/java/com/packit/api/domain/trip/dto/response/TripResponse.java
@@ -1,0 +1,30 @@
+package com.packit.api.domain.trip.dto.response;
+
+import com.packit.api.domain.trip.entity.Trip;
+import com.packit.api.domain.trip.entity.TripType;
+
+import java.time.LocalDate;
+
+public record TripResponse(
+        Long id,
+        String title,
+        String region,
+        TripType tripType,
+        LocalDate startDate,
+        LocalDate endDate,
+        String description,
+        boolean isCompleted
+) {
+    public static TripResponse from(Trip trip) {
+        return new TripResponse(
+                trip.getId(),
+                trip.getTitle(),
+                trip.getRegion(),
+                trip.getTripType(),
+                trip.getStartDate(),
+                trip.getEndDate(),
+                trip.getDescription(),
+                trip.isCompleted()
+        );
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/trip/entity/Trip.java
+++ b/api/src/main/java/com/packit/api/domain/trip/entity/Trip.java
@@ -1,0 +1,72 @@
+package com.packit.api.domain.trip.entity;
+
+import com.packit.api.common.BaseTimeEntity;
+import com.packit.api.domain.trip.dto.request.TripCreateRequest;
+import com.packit.api.domain.trip.dto.request.TripUpdateRequest;
+import com.packit.api.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Trip extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    private String title;
+    private String region;
+
+    @Enumerated(EnumType.STRING)
+    private TripType tripType;
+
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    private String description;
+
+    private boolean isCompleted;
+
+    @Builder
+    private Trip(User user, String title, String region, TripType tripType,
+                 LocalDate startDate, LocalDate endDate, String description) {
+        this.user = user;
+        this.title = title;
+        this.region = region;
+        this.tripType = tripType;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.description = description;
+        this.isCompleted = false;
+    }
+
+    public static Trip of(User user, TripCreateRequest request) {
+        return Trip.builder()
+                .user(user)
+                .title(request.title())
+                .region(request.region())
+                .tripType(request.tripType())
+                .startDate(request.startDate())
+                .endDate(request.endDate())
+                .description(request.description())
+                .build();
+    }
+    public void update(TripUpdateRequest request) {
+        this.title = request.title();
+        this.region = request.region();
+        this.tripType = request.tripType();
+        this.startDate = request.startDate();
+        this.endDate = request.endDate();
+        this.description = request.description();
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/trip/entity/TripType.java
+++ b/api/src/main/java/com/packit/api/domain/trip/entity/TripType.java
@@ -1,0 +1,25 @@
+package com.packit.api.domain.trip.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Schema(description = "여행 유형 (FAMILY: 가족여행, FRIEND: 친구여행, BUSINESS: 출장, OTHER: 기타)")
+public enum TripType {
+
+    @Schema(description = "가족 여행")
+    FAMILY("가족"),
+
+    @Schema(description = "친구와의 여행")
+    FRIEND("친구"),
+
+    @Schema(description = "출장")
+    BUSINESS("출장"),
+
+    @Schema(description = "기타")
+    OTHER("기타");
+
+    private final String displayName;
+}

--- a/api/src/main/java/com/packit/api/domain/trip/repository/TripRepository.java
+++ b/api/src/main/java/com/packit/api/domain/trip/repository/TripRepository.java
@@ -1,0 +1,11 @@
+package com.packit.api.domain.trip.repository;
+
+import com.packit.api.domain.trip.entity.Trip;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface TripRepository extends JpaRepository<Trip, Long> {
+    List<Trip> findAllByUserId(Long userId);
+}

--- a/api/src/main/java/com/packit/api/domain/trip/service/TripService.java
+++ b/api/src/main/java/com/packit/api/domain/trip/service/TripService.java
@@ -1,0 +1,64 @@
+package com.packit.api.domain.trip.service;
+
+import com.packit.api.common.security.util.SecurityUtils;
+import com.packit.api.domain.trip.dto.request.TripCreateRequest;
+import com.packit.api.domain.trip.dto.request.TripUpdateRequest;
+import com.packit.api.domain.trip.dto.response.TripResponse;
+import com.packit.api.domain.trip.entity.Trip;
+import com.packit.api.domain.trip.repository.TripRepository;
+import com.packit.api.domain.user.entity.User;
+import com.packit.api.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.catalina.security.SecurityUtil;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TripService {
+    private final UserRepository userRepository;
+    private final TripRepository tripRepository;
+
+    public TripResponse createTrip(TripCreateRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Trip trip = Trip.of(user, request);
+        tripRepository.save(trip);
+
+        return TripResponse.from(trip);
+    }
+
+    public List<TripResponse> getTripList(Long userId) {
+        return tripRepository.findAllByUserId(userId).stream()
+                .map(TripResponse::from)
+                .toList();
+    }
+
+    public TripResponse getTripDetail(Long tripId, Long userId) {
+        Trip trip = validateTripOwner(tripId, userId);
+        return TripResponse.from(trip);
+    }
+
+    public TripResponse updateTrip(Long tripId, Long userId, TripUpdateRequest request) {
+        Trip trip = validateTripOwner(tripId, userId);
+        trip.update(request);  // 아래에 정의된 update 메서드 참고
+        return TripResponse.from(trip);
+    }
+
+    public void deleteTrip(Long tripId, Long userId) {
+        Trip trip = validateTripOwner(tripId, userId);
+        tripRepository.delete(trip);
+    }
+
+    private Trip validateTripOwner(Long tripId, Long userId) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 여행을 찾을 수 없습니다."));
+        if (!trip.getUser().getId().equals(userId)) {
+            throw new SecurityException("본인의 여행만 조회/수정/삭제할 수 있습니다.");
+        }
+        return trip;
+    }
+}


### PR DESCRIPTION
## 작업 내용
- Trip 엔티티 및 TripType Enum 정의
- Trip 생성(Create), 조회(Read), 수정(Update), 삭제(Delete) API 구현
- TripController, TripService, TripRepository 구성
- TripCreateRequest / TripUpdateRequest / TripResponse DTO 설계
- SecurityContext에서 사용자 ID 추출하여 Trip 연동
- Swagger 문서화 (@Operation, @Parameter 등 적용)
- TripType enum에 displayName 추가 및 문서화

## API 명세
| 기능 | Method | URL | 설명 |
|------|--------|-----|------|
| 여행 생성 | POST | `/api/trips` | 사용자의 여행 추가 |
| 여행 목록 조회 | GET | `/api/trips` | 로그인한 사용자의 전체 여행 목록 |
| 여행 상세 조회 | GET | `/api/trips/{id}` | 특정 여행 상세 정보 |
| 여행 수정 | PATCH | `/api/trips/{id}` | 여행 정보 일부 수정 |
| 여행 삭제 | DELETE | `/api/trips/{id}` | 해당 여행 삭제 |

## 테스트
- Swagger UI에서 각 기능 정상 동작 확인
- 비로그인 사용자 접근 시 401 에러 확인
- 사용자 본인의 여행만 조회/수정/삭제 가능하도록 검증 완료

## 📌 참고 사항
- TripType enum에 한글 설명 포함 (Swagger 문서에서도 확인 가능)
- 추후 TripCategory 연동 예정 (Trip ID 기준으로 연결)
