### PR TITLE
feat: 기본 카테고리 및 템플릿 아이템 도메인 및 시드 데이터 구현

### DIFF
--- a/api/src/main/java/com/packit/api/common/Gender.java
+++ b/api/src/main/java/com/packit/api/common/Gender.java
@@ -1,0 +1,7 @@
+package com.packit.api.common;
+
+public enum Gender {
+    MALE,
+    FEMALE,
+    BOTH
+}

--- a/api/src/main/java/com/packit/api/common/Init/DataInitializer.java
+++ b/api/src/main/java/com/packit/api/common/Init/DataInitializer.java
@@ -1,0 +1,80 @@
+package com.packit.api.common.Init;
+
+import com.packit.api.common.Gender;
+import com.packit.api.domain.TemplateItem.entity.TemplateItem;
+import com.packit.api.domain.TemplateItem.repository.TemplateItemRepository;
+import com.packit.api.domain.category.entity.Category;
+import com.packit.api.domain.category.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DataInitializer implements CommandLineRunner {
+
+    private final CategoryRepository categoryRepository;
+    private final TemplateItemRepository templateItemRepository;
+
+    @Override
+    public void run(String... args) {
+        if (categoryRepository.count() > 0) return;
+
+        Category essentials = categoryRepository.save(Category.of("필수품"));
+        Category clothes = categoryRepository.save(Category.of("의류 & 액세서리"));
+        Category hygiene = categoryRepository.save(Category.of("세면도구 & 위생품"));
+        Category health = categoryRepository.save(Category.of("건강 & 응급 용품"));
+        Category electronics = categoryRepository.save(Category.of("전자기기"));
+
+        templateItemRepository.saveAll(List.of(
+                // 필수품
+                TemplateItem.of(essentials, "여권", 1, Gender.BOTH),
+                TemplateItem.of(essentials, "신분증", 1, Gender.BOTH),
+                TemplateItem.of(essentials, "항공권", 1, Gender.BOTH),
+                TemplateItem.of(essentials, "기차표", 1, Gender.BOTH),
+                TemplateItem.of(essentials, "숙소 예약 확인서", 1, Gender.BOTH),
+                TemplateItem.of(essentials, "신용카드", 1, Gender.BOTH),
+                TemplateItem.of(essentials, "현금", 1, Gender.BOTH),
+
+                // 의류 & 액세서리
+                TemplateItem.of(clothes, "상의", 2, Gender.BOTH),
+                TemplateItem.of(clothes, "하의", 2, Gender.BOTH),
+                TemplateItem.of(clothes, "외투", 1, Gender.BOTH),
+                TemplateItem.of(clothes, "속옷", 3, Gender.BOTH),
+                TemplateItem.of(clothes, "양말", 3, Gender.BOTH),
+                TemplateItem.of(clothes, "신발", 1, Gender.BOTH),
+                TemplateItem.of(clothes, "모자", 1, Gender.BOTH),
+                TemplateItem.of(clothes, "선글라스", 1, Gender.BOTH),
+                TemplateItem.of(clothes, "장갑", 1, Gender.BOTH),
+
+                // 세면도구 & 위생품
+                TemplateItem.of(hygiene, "칫솔, 치약", 1, Gender.BOTH),
+                TemplateItem.of(hygiene, "샴푸, 린스", 1, Gender.BOTH),
+                TemplateItem.of(hygiene, "바디워시", 1, Gender.BOTH),
+                TemplateItem.of(hygiene, "기초 스킨케어", 1, Gender.BOTH),
+                TemplateItem.of(hygiene, "선크림", 1, Gender.BOTH),
+                TemplateItem.of(hygiene, "화장품", 1, Gender.BOTH),
+                TemplateItem.of(hygiene, "물티슈", 1, Gender.BOTH),
+                TemplateItem.of(hygiene, "휴지", 1, Gender.BOTH),
+                TemplateItem.of(hygiene, "생리용품", 1, Gender.FEMALE),
+
+                // 건강 & 응급 용품
+                TemplateItem.of(health, "개인 내복약", 1, Gender.BOTH),
+                TemplateItem.of(health, "진통제", 1, Gender.BOTH),
+                TemplateItem.of(health, "소화제", 1, Gender.BOTH),
+                TemplateItem.of(health, "알러지약", 1, Gender.BOTH),
+                TemplateItem.of(health, "반창고 & 연고", 1, Gender.BOTH),
+                TemplateItem.of(health, "소독약", 1, Gender.BOTH),
+                TemplateItem.of(health, "마스크", 3, Gender.BOTH),
+
+                // 전자기기
+                TemplateItem.of(electronics, "핸드폰", 1, Gender.BOTH),
+                TemplateItem.of(electronics, "노트북 & 태블릿", 1, Gender.BOTH),
+                TemplateItem.of(electronics, "충전기", 1, Gender.BOTH),
+                TemplateItem.of(electronics, "보조배터리", 1, Gender.BOTH),
+                TemplateItem.of(electronics, "이어폰, 헤드폰", 1, Gender.BOTH)
+        ));
+    }
+}

--- a/api/src/main/java/com/packit/api/common/security/dto/SignupRequestDto.java
+++ b/api/src/main/java/com/packit/api/common/security/dto/SignupRequestDto.java
@@ -1,6 +1,6 @@
 package com.packit.api.common.security.dto;
 
-import com.packit.api.domain.user.entity.Gender;
+import com.packit.api.common.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/api/src/main/java/com/packit/api/domain/TemplateItem/entity/TemplateItem.java
+++ b/api/src/main/java/com/packit/api/domain/TemplateItem/entity/TemplateItem.java
@@ -1,0 +1,46 @@
+package com.packit.api.domain.TemplateItem.entity;
+
+import com.packit.api.common.Gender;
+import com.packit.api.domain.category.entity.Category;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TemplateItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Category category;
+
+    private String name;
+
+    private Integer defaultQuantity;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender; // MALE, FEMALE, BOTH
+
+    @Builder
+    private TemplateItem(Category category, String name, Integer defaultQuantity, Gender gender) {
+        this.category = category;
+        this.name = name;
+        this.defaultQuantity = defaultQuantity;
+        this.gender = gender;
+    }
+
+    public static TemplateItem of(Category category, String name, int defaultQuantity, Gender gender) {
+        return TemplateItem.builder()
+                .category(category)
+                .name(name)
+                .defaultQuantity(defaultQuantity)
+                .gender(gender)
+                .build();
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/TemplateItem/repository/TemplateItemRepository.java
+++ b/api/src/main/java/com/packit/api/domain/TemplateItem/repository/TemplateItemRepository.java
@@ -1,0 +1,6 @@
+package com.packit.api.domain.TemplateItem.repository;
+
+import com.packit.api.domain.TemplateItem.entity.TemplateItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TemplateItemRepository extends JpaRepository<TemplateItem, Long> {}

--- a/api/src/main/java/com/packit/api/domain/category/entity/Category.java
+++ b/api/src/main/java/com/packit/api/domain/category/entity/Category.java
@@ -1,0 +1,29 @@
+package com.packit.api.domain.category.entity;
+
+import com.packit.api.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Builder
+    private Category(String name) {
+        this.name = name;
+    }
+
+    public static Category of(String name) {
+        return Category.builder().name(name).build();
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/category/repository/CategoryRepository.java
+++ b/api/src/main/java/com/packit/api/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,11 @@
+package com.packit.api.domain.category.repository;
+
+import com.packit.api.domain.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    Optional<Category> findByName(String name);
+}
+

--- a/api/src/main/java/com/packit/api/domain/user/entity/Gender.java
+++ b/api/src/main/java/com/packit/api/domain/user/entity/Gender.java
@@ -1,6 +1,0 @@
-package com.packit.api.domain.user.entity;
-
-public enum Gender {
-    MALE,
-    FEMALE
-}

--- a/api/src/main/java/com/packit/api/domain/user/entity/User.java
+++ b/api/src/main/java/com/packit/api/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.packit.api.domain.user.entity;
 
 import com.packit.api.common.BaseTimeEntity;
+import com.packit.api.common.Gender;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;


### PR DESCRIPTION
##  작업 내용
- Category, TemplateItem 엔티티 생성
  - Category: 기본 제공 카테고리 (ex. 의류, 전자기기 등)
  - TemplateItem: 카테고리별 기본 아이템 정의 (ex. 양말, 칫솔 등)
- Gender enum 재사용 (MALE / FEMALE / BOTH)
- Repository 정의: CategoryRepository, TemplateItemRepository

##  시드 데이터 구성 (CommandLineRunner 기반)
- 앱 실행 시 최초 1회만 기본 데이터 자동 삽입
- 중복 삽입 방지를 위해 `categoryRepository.count()` 체크 포함
- 총 5개 카테고리 + 카테고리별 대표 아이템 등록

##  카테고리 목록
- 필수품
- 의류 & 액세서리
- 세면도구 & 위생품
- 건강 & 응급 용품
- 전자기기

##  예시 아이템
- `의류 & 액세서리`: 상의, 하의, 외투, 양말, 모자 등
- `세면도구 & 위생품`: 칫솔, 치약, 샴푸, 선크림 등
- `전자기기`: 충전기, 핸드폰, 노트북 등

## 테스트
- 앱 실행 후 DB에 기본 Category / TemplateItem 데이터 삽입 확인
- TripCategory에서 Category 참조 가능
- TemplateItem도 추후 TripItem 생성 시 활용 가능

##  참고 사항
- 시드 데이터는 `@Component` + `CommandLineRunner`로 구성
- `@Profile("local")` 등 환경 제한은 아직 적용하지 않음