### PR TITLE
feat: TripCategory 도메인 및 CRUD 기능 구현

### DIFF
--- a/api/src/main/java/com/packit/api/domain/tripCategory/controller/TripCategoryController.java
+++ b/api/src/main/java/com/packit/api/domain/tripCategory/controller/TripCategoryController.java
@@ -1,0 +1,58 @@
+package com.packit.api.domain.tripCategory.controller;
+
+import com.packit.api.common.security.util.SecurityUtils;
+import com.packit.api.domain.tripCategory.dto.request.TripCategoryCreateRequest;
+import com.packit.api.domain.tripCategory.dto.response.TripCategoryResponse;
+import com.packit.api.domain.tripCategory.entity.TripCategoryStatus;
+import com.packit.api.domain.tripCategory.service.TripCategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/trips")
+@RequiredArgsConstructor
+@Tag(name = "TripCategory", description = "여행 카테고리 관리 API")
+public class TripCategoryController {
+
+    private final TripCategoryService tripCategoryService;
+
+    @Operation(summary = "여행에 카테고리 추가", description = "기본 카테고리 선택 또는 사용자 정의 카테고리를 여행에 추가합니다.")
+    @PostMapping("/{tripId}/categories")
+    public ResponseEntity<TripCategoryResponse> createCategory(
+            @PathVariable Long tripId,
+            @RequestBody @Valid TripCategoryCreateRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(tripCategoryService.create(tripId, request, userId));
+    }
+
+    @Operation(summary = "여행 카테고리 목록 조회", description = "여행 ID에 해당하는 모든 카테고리를 조회합니다.")
+    @GetMapping("/{tripId}/categories")
+    public ResponseEntity<List<TripCategoryResponse>> getCategories(@PathVariable Long tripId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(tripCategoryService.getTripCategories(tripId, userId));
+    }
+
+    @Operation(summary = "카테고리 상태 변경", description = "짐싸기 상태(NOT_STARTED, IN_PROGRESS, COMPLETED)를 변경합니다.")
+    @PatchMapping("/categories/{id}")
+    public ResponseEntity<Void> updateStatus(
+            @PathVariable Long id,
+            @RequestParam TripCategoryStatus status) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        tripCategoryService.updateStatus(id, status, userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "카테고리 삭제", description = "여행 카테고리를 삭제합니다.")
+    @DeleteMapping("/categories/{id}")
+    public ResponseEntity<Void> deleteCategory(@PathVariable Long id) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        tripCategoryService.delete(id, userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/tripCategory/dto/request/TripCategoryCreateRequest.java
+++ b/api/src/main/java/com/packit/api/domain/tripCategory/dto/request/TripCategoryCreateRequest.java
@@ -1,0 +1,15 @@
+package com.packit.api.domain.tripCategory.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "여행 카테고리 생성 요청")
+public record TripCategoryCreateRequest(
+
+        @Schema(description = "기본 카테고리 ID (없을 경우 사용자 정의)", example = "1")
+        Long categoryId,
+
+        @NotBlank
+        @Schema(description = "카테고리 이름", example = "전자기기")
+        String name
+) {}

--- a/api/src/main/java/com/packit/api/domain/tripCategory/dto/response/TripCategoryResponse.java
+++ b/api/src/main/java/com/packit/api/domain/tripCategory/dto/response/TripCategoryResponse.java
@@ -1,0 +1,20 @@
+package com.packit.api.domain.tripCategory.dto.response;
+
+import com.packit.api.domain.tripCategory.entity.TripCategory;
+import com.packit.api.domain.tripCategory.entity.TripCategoryStatus;
+
+public record TripCategoryResponse(
+        Long id,
+        String name,
+        TripCategoryStatus status,
+        boolean isDefault
+) {
+    public static TripCategoryResponse from(TripCategory tripCategory) {
+        return new TripCategoryResponse(
+                tripCategory.getId(),
+                tripCategory.getName(),
+                tripCategory.getStatus(),
+                tripCategory.getCategory() != null
+        );
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/tripCategory/entity/TripCategory.java
+++ b/api/src/main/java/com/packit/api/domain/tripCategory/entity/TripCategory.java
@@ -1,0 +1,53 @@
+package com.packit.api.domain.tripCategory.entity;
+
+import com.packit.api.common.BaseTimeEntity;
+import com.packit.api.domain.category.entity.Category;
+import com.packit.api.domain.trip.entity.Trip;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TripCategory extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Trip trip;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Category category; // nullable
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private TripCategoryStatus status;
+
+    @Builder
+    private TripCategory(Trip trip, Category category, String name, TripCategoryStatus status) {
+        this.trip = trip;
+        this.category = category;
+        this.name = name;
+        this.status = status;
+    }
+
+    public static TripCategory of(Trip trip, Category category, String name) {
+        return TripCategory.builder()
+                .trip(trip)
+                .category(category) // null 가능
+                .name(name)
+                .status(TripCategoryStatus.NOT_STARTED)
+                .build();
+    }
+
+    public void updateStatus(TripCategoryStatus status) {
+        this.status = status;
+    }
+
+
+}

--- a/api/src/main/java/com/packit/api/domain/tripCategory/entity/TripCategoryStatus.java
+++ b/api/src/main/java/com/packit/api/domain/tripCategory/entity/TripCategoryStatus.java
@@ -1,0 +1,23 @@
+package com.packit.api.domain.tripCategory.entity;
+
+import com.packit.api.common.BaseTimeEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Schema(description = "짐싸기 상태")
+public enum TripCategoryStatus {
+
+    @Schema(description = "짐싸기를 시작하지 않음")
+    NOT_STARTED("시작 전"),
+
+    @Schema(description = "짐싸기 진행 중")
+    IN_PROGRESS("진행 중"),
+
+    @Schema(description = "짐싸기 완료")
+    COMPLETED("완료");
+
+    private final String displayName;
+}

--- a/api/src/main/java/com/packit/api/domain/tripCategory/repository/TripCategoryRepository.java
+++ b/api/src/main/java/com/packit/api/domain/tripCategory/repository/TripCategoryRepository.java
@@ -1,0 +1,10 @@
+package com.packit.api.domain.tripCategory.repository;
+
+import com.packit.api.domain.tripCategory.entity.TripCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TripCategoryRepository extends JpaRepository<TripCategory, Long> {
+    List<TripCategory> findAllByTripId(Long tripId);
+}

--- a/api/src/main/java/com/packit/api/domain/tripCategory/service/TripCategoryService.java
+++ b/api/src/main/java/com/packit/api/domain/tripCategory/service/TripCategoryService.java
@@ -1,0 +1,73 @@
+package com.packit.api.domain.tripCategory.service;
+
+import com.packit.api.domain.category.entity.Category;
+import com.packit.api.domain.category.repository.CategoryRepository;
+import com.packit.api.domain.trip.entity.Trip;
+import com.packit.api.domain.trip.repository.TripRepository;
+import com.packit.api.domain.tripCategory.dto.request.TripCategoryCreateRequest;
+import com.packit.api.domain.tripCategory.dto.response.TripCategoryResponse;
+import com.packit.api.domain.tripCategory.entity.TripCategory;
+import com.packit.api.domain.tripCategory.entity.TripCategoryStatus;
+import com.packit.api.domain.tripCategory.repository.TripCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TripCategoryService {
+
+    private final TripRepository tripRepository;
+    private final CategoryRepository categoryRepository;
+    private final TripCategoryRepository tripCategoryRepository;
+
+    public TripCategoryResponse create(Long tripId, TripCategoryCreateRequest request, Long userId) {
+        Trip trip = getTripOwnedByUser(tripId, userId);
+
+        Category category = null;
+        if (request.categoryId() != null) {
+            category = categoryRepository.findById(request.categoryId())
+                    .orElseThrow(() -> new IllegalArgumentException("해당 카테고리를 찾을 수 없습니다."));
+        }
+
+        TripCategory tripCategory = TripCategory.of(trip, category, request.name());
+        tripCategoryRepository.save(tripCategory);
+
+        return TripCategoryResponse.from(tripCategory);
+    }
+
+    public List<TripCategoryResponse> getTripCategories(Long tripId, Long userId) {
+        getTripOwnedByUser(tripId, userId); // 권한 검증
+        return tripCategoryRepository.findAllByTripId(tripId).stream()
+                .map(TripCategoryResponse::from)
+                .toList();
+    }
+
+    public void updateStatus(Long tripCategoryId, TripCategoryStatus status, Long userId) {
+        TripCategory tripCategory = tripCategoryRepository.findById(tripCategoryId)
+                .orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다."));
+        validateTripOwner(tripCategory.getTrip(), userId);
+        tripCategory.updateStatus(status);
+    }
+
+    public void delete(Long tripCategoryId, Long userId) {
+        TripCategory tripCategory = tripCategoryRepository.findById(tripCategoryId)
+                .orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다."));
+        validateTripOwner(tripCategory.getTrip(), userId);
+        tripCategoryRepository.delete(tripCategory);
+    }
+
+    private Trip getTripOwnedByUser(Long tripId, Long userId) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new IllegalArgumentException("여행을 찾을 수 없습니다."));
+        validateTripOwner(trip, userId);
+        return trip;
+    }
+
+    private void validateTripOwner(Trip trip, Long userId) {
+        if (!trip.getUser().getId().equals(userId)) {
+            throw new SecurityException("본인의 여행만 접근할 수 있습니다.");
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용
- TripCategory 엔티티 설계 및 생성 로직 구현
  - 기본 제공 카테고리(Category) 연결 가능
  - 사용자 정의 카테고리는 categoryId 없이 name만 저장
- TripCategoryStatus enum 정의 (NOT_STARTED, IN_PROGRESS, COMPLETED)

## API 명세

| 기능 | Method | URL | 설명 |
|------|--------|-----|------|
| 카테고리 생성 | POST | `/api/trips/{tripId}/categories` | 기본 or 사용자 정의 카테고리 추가 |
| 목록 조회 | GET | `/api/trips/{tripId}/categories` | 여행별 카테고리 전체 조회 |
| 상태 변경 | PATCH | `/api/trips/categories/{id}?status=IN_PROGRESS` | 짐싸기 상태 업데이트 |
| 카테고리 삭제 | DELETE | `/api/trips/categories/{id}` | 해당 카테고리 삭제 |

## 주요 구현 내용
- TripCategory.of() 정적 팩토리 메서드 사용
- TripCategoryResponse DTO에서 `isDefault` 플래그 제공
- TripCategoryService에서 사용자 권한 검증 포함 (`trip.user.id` 비교)

## 테스트
- Swagger UI에서 전체 API 정상 동작 확인
- 카테고리 상태 변경 시 Enum값으로 상태 전환 확인
- 본인 여행이 아닌 경우 SecurityException 발생

## 참고 사항
- Category/TemplateItem 기능은 이전 PR에서 선 반영됨
- 이후 TripItem 생성 시 TripCategory와 연동 예정