### PR TITLE
feat: TripItem CRUD 및 템플릿 아이템 복사 기능 구현Feat/trip item

### DIFF
--- a/api/src/main/java/com/packit/api/domain/tripItem/controller/TripItemController.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/controller/TripItemController.java
@@ -1,0 +1,63 @@
+package com.packit.api.domain.tripItem.controller;
+
+import com.packit.api.common.security.util.SecurityUtils;
+import com.packit.api.domain.tripItem.dto.request.TripItemCreateRequest;
+import com.packit.api.domain.tripItem.dto.response.TripItemResponse;
+import com.packit.api.domain.tripItem.service.TripItemService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+@RestController
+@RequestMapping("/api/trip-categories")
+@RequiredArgsConstructor
+@Tag(name = "TripItem", description = "짐 아이템 관리 API")
+public class TripItemController {
+
+    private final TripItemService tripItemService;
+
+    @Operation(summary = "아이템 생성", description = "카테고리 내에 새로운 짐 아이템을 추가합니다.")
+    @PostMapping("/{categoryId}/items")
+    public ResponseEntity<TripItemResponse> createItem(
+            @PathVariable Long categoryId,
+            @RequestBody @Valid TripItemCreateRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(tripItemService.create(categoryId, request, userId));
+    }
+
+    @Operation(summary = "아이템 목록 조회", description = "해당 카테고리에 속한 모든 아이템을 조회합니다.")
+    @GetMapping("/{categoryId}/items")
+    public ResponseEntity<List<TripItemResponse>> getItems(@PathVariable Long categoryId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(tripItemService.getAll(categoryId, userId));
+    }
+
+    @Operation(summary = "아이템 수정", description = "아이템 이름, 수량, 메모를 수정합니다.")
+    @PatchMapping("/items/{itemId}")
+    public ResponseEntity<TripItemResponse> updateItem(
+            @PathVariable Long itemId,
+            @RequestBody @Valid TripItemCreateRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(tripItemService.update(itemId, request, userId));
+    }
+
+    @Operation(summary = "짐싸기 체크 여부 토글", description = "isChecked 상태를 토글합니다.")
+    @PatchMapping("/items/{itemId}/check")
+    public ResponseEntity<Void> toggleCheck(@PathVariable Long itemId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        tripItemService.toggleCheck(itemId, userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "아이템 삭제", description = "짐 아이템을 삭제합니다.")
+    @DeleteMapping("/items/{itemId}")
+    public ResponseEntity<Void> deleteItem(@PathVariable Long itemId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        tripItemService.delete(itemId, userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/tripItem/controller/TripItemController.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/controller/TripItemController.java
@@ -2,6 +2,7 @@ package com.packit.api.domain.tripItem.controller;
 
 import com.packit.api.common.security.util.SecurityUtils;
 import com.packit.api.domain.tripItem.dto.request.TripItemCreateRequest;
+import com.packit.api.domain.tripItem.dto.request.TripItemFromTemplateRequest;
 import com.packit.api.domain.tripItem.dto.response.TripItemResponse;
 import com.packit.api.domain.tripItem.service.TripItemService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -59,5 +60,15 @@ public class TripItemController {
         Long userId = SecurityUtils.getCurrentUserId();
         tripItemService.delete(itemId, userId);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "템플릿 아이템 복사", description = "선택한 템플릿 아이템을 TripItem으로 복사합니다.")
+    @PostMapping("/{categoryId}/items/from-template")
+    public ResponseEntity<Void> addFromTemplate(
+            @PathVariable Long categoryId,
+            @RequestBody TripItemFromTemplateRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        tripItemService.addItemsFromTemplate(categoryId, request.templateItemIds(), userId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/api/src/main/java/com/packit/api/domain/tripItem/dto/request/TripItemCreateRequest.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/dto/request/TripItemCreateRequest.java
@@ -1,0 +1,7 @@
+package com.packit.api.domain.tripItem.dto.request;
+
+public record TripItemCreateRequest(
+        String name,
+        Integer quantity,
+        String memo
+) {}

--- a/api/src/main/java/com/packit/api/domain/tripItem/dto/request/TripItemFromTemplateRequest.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/dto/request/TripItemFromTemplateRequest.java
@@ -1,0 +1,7 @@
+package com.packit.api.domain.tripItem.dto.request;
+
+import java.util.List;
+
+public record TripItemFromTemplateRequest (
+    List<Long> templateItemIds
+) {}

--- a/api/src/main/java/com/packit/api/domain/tripItem/dto/response/TripItemResponse.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/dto/response/TripItemResponse.java
@@ -1,0 +1,25 @@
+package com.packit.api.domain.tripItem.dto.response;
+
+import com.packit.api.domain.tripItem.entity.TripItem;
+
+public record TripItemResponse(
+        Long id,
+        String name,
+        Integer quantity,
+        boolean isChecked,
+        boolean isSaved,
+        boolean isAiGenerated,
+        String memo
+) {
+    public static TripItemResponse from(TripItem item) {
+        return new TripItemResponse(
+                item.getId(),
+                item.getName(),
+                item.getQuantity(),
+                item.isChecked(),
+                item.isSaved(),
+                item.isAiGenerated(),
+                item.getMemo()
+        );
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/tripItem/entity/TripItem.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/entity/TripItem.java
@@ -1,0 +1,68 @@
+package com.packit.api.domain.tripItem.entity;
+
+import com.packit.api.common.BaseTimeEntity;
+import com.packit.api.domain.tripCategory.entity.TripCategory;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TripItem extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private TripCategory tripCategory;
+
+    private String name;
+
+    private Integer quantity;
+
+    private boolean isChecked;
+
+    private boolean isSaved;
+
+    private boolean isAiGenerated;
+
+    private String memo;
+
+    @Builder
+    private TripItem(TripCategory tripCategory, String name, Integer quantity,
+                     boolean isChecked, boolean isSaved, boolean isAiGenerated, String memo) {
+        this.tripCategory = tripCategory;
+        this.name = name;
+        this.quantity = quantity;
+        this.isChecked = isChecked;
+        this.isSaved = isSaved;
+        this.isAiGenerated = isAiGenerated;
+        this.memo = memo;
+    }
+
+    public static TripItem of(TripCategory tripCategory, String name, Integer quantity) {
+        return TripItem.builder()
+                .tripCategory(tripCategory)
+                .name(name)
+                .quantity(quantity)
+                .isChecked(false)
+                .isSaved(true)
+                .isAiGenerated(false)
+                .memo(null)
+                .build();
+    }
+
+    public void toggleCheck() {
+        this.isChecked = !this.isChecked;
+    }
+
+    public void update(String name, Integer quantity, String memo) {
+        this.name = name;
+        this.quantity = quantity;
+        this.memo = memo;
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/tripItem/repository/TripItemRepository.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/repository/TripItemRepository.java
@@ -1,0 +1,10 @@
+package com.packit.api.domain.tripItem.repository;
+
+import com.packit.api.domain.tripItem.entity.TripItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TripItemRepository extends JpaRepository<TripItem, Long> {
+    List<TripItem> findAllByTripCategoryId(Long tripCategoryId);
+}

--- a/api/src/main/java/com/packit/api/domain/tripItem/service/TripItemService.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/service/TripItemService.java
@@ -1,0 +1,71 @@
+package com.packit.api.domain.tripItem.service;
+
+import com.packit.api.domain.tripCategory.entity.TripCategory;
+import com.packit.api.domain.tripCategory.repository.TripCategoryRepository;
+import com.packit.api.domain.tripItem.dto.request.TripItemCreateRequest;
+import com.packit.api.domain.tripItem.dto.response.TripItemResponse;
+import com.packit.api.domain.tripItem.entity.TripItem;
+import com.packit.api.domain.tripItem.repository.TripItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TripItemService {
+
+    private final TripItemRepository tripItemRepository;
+    private final TripCategoryRepository tripCategoryRepository;
+
+    public TripItemResponse create(Long tripCategoryId, TripItemCreateRequest request, Long userId) {
+        TripCategory category = getCategoryOwnedByUser(tripCategoryId, userId);
+        TripItem item = TripItem.of(category, request.name(), request.quantity());
+        item.update(request.name(), request.quantity(), request.memo());
+        tripItemRepository.save(item);
+        return TripItemResponse.from(item);
+    }
+
+    public List<TripItemResponse> getAll(Long tripCategoryId, Long userId) {
+        getCategoryOwnedByUser(tripCategoryId, userId);
+        return tripItemRepository.findAllByTripCategoryId(tripCategoryId).stream()
+                .map(TripItemResponse::from)
+                .toList();
+    }
+
+    public TripItemResponse update(Long itemId, TripItemCreateRequest request, Long userId) {
+        TripItem item = getItemOwnedByUser(itemId, userId);
+        item.update(request.name(), request.quantity(), request.memo());
+        return TripItemResponse.from(item);
+    }
+
+    public void toggleCheck(Long itemId, Long userId) {
+        TripItem item = getItemOwnedByUser(itemId, userId);
+        item.toggleCheck();
+    }
+
+    public void delete(Long itemId, Long userId) {
+        TripItem item = getItemOwnedByUser(itemId, userId);
+        tripItemRepository.delete(item);
+    }
+
+    private TripItem getItemOwnedByUser(Long itemId, Long userId) {
+        TripItem item = tripItemRepository.findById(itemId)
+                .orElseThrow(() -> new IllegalArgumentException("아이템을 찾을 수 없습니다."));
+        validateTripCategoryOwner(item.getTripCategory(), userId);
+        return item;
+    }
+
+    private TripCategory getCategoryOwnedByUser(Long tripCategoryId, Long userId) {
+        TripCategory category = tripCategoryRepository.findById(tripCategoryId)
+                .orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다."));
+        validateTripCategoryOwner(category, userId);
+        return category;
+    }
+
+    private void validateTripCategoryOwner(TripCategory category, Long userId) {
+        if (!category.getTrip().getUser().getId().equals(userId)) {
+            throw new SecurityException("본인의 여행 항목만 관리할 수 있습니다.");
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용

- TripItem 도메인 구현
  - 여행 카테고리(TripCategory) 하위의 짐 항목 (TripItem) 추가
  - 항목 수량, 이름, 메모, 체크 여부 등 관리

- TripItem API 구현
  - TripItem 생성 (POST /trip-categories/{id}/items)
  - TripItem 목록 조회 (GET /trip-categories/{id}/items)
  - TripItem 수정 (PATCH /trip-categories/items/{id})
  - TripItem 체크 상태 토글 (PATCH /trip-categories/items/{id}/check)
  - TripItem 삭제 (DELETE /trip-categories/items/{id})

- 템플릿 아이템 복사 기능 추가
  - TemplateItem ID 목록을 입력받아 TripItem으로 복사
  - API: POST /trip-categories/{id}/items/from-template


---

##  API 명세

| 기능 | Method | URL | 설명 |
|------|--------|-----|------|
| 아이템 생성 | POST | /trip-categories/{id}/items | TripCategory에 항목 추가 |
| 목록 조회 | GET | /trip-categories/{id}/items | 카테고리 내 전체 아이템 조회 |
| 수정 | PATCH | /trip-categories/items/{id} | 수량, 이름, 메모 수정 |
| 체크 토글 | PATCH | /trip-categories/items/{id}/check | 체크 상태 반전 |
| 삭제 | DELETE | /trip-categories/items/{id} | 항목 삭제 |
| 템플릿 복사 | POST | /trip-categories/{id}/items/from-template | TemplateItem → TripItem 복사 |

---

## 참고 사항

- 추후 AI 추천 항목도 `TripItem`으로 삽입 예정 (isAiGenerated = true)
- 추후 Trip 전체 진행률 계산 또는 TripCategory 상태 자동 갱신 API 예정