### PR TITLE
feat: Trip 및 TripCategory 진행률 조회 API 구현

### DIFF
--- a/api/src/main/java/com/packit/api/domain/trip/controller/TripController.java
+++ b/api/src/main/java/com/packit/api/domain/trip/controller/TripController.java
@@ -3,6 +3,7 @@ package com.packit.api.domain.trip.controller;
 import com.packit.api.common.security.util.SecurityUtils;
 import com.packit.api.domain.trip.dto.request.TripCreateRequest;
 import com.packit.api.domain.trip.dto.request.TripUpdateRequest;
+import com.packit.api.domain.trip.dto.response.TripProgressResponse;
 import com.packit.api.domain.trip.dto.response.TripResponse;
 import com.packit.api.domain.trip.service.TripService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -72,5 +73,12 @@ public class TripController {
         Long userId = SecurityUtils.getCurrentUserId();
         tripService.deleteTrip(id, userId);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "전체 짐싸기 진행률 조회", description = "여행 내 전체 카테고리의 짐싸기 완료 상태를 기반으로 진행률을 반환합니다.")
+    @GetMapping("/{tripId}/progress")
+    public ResponseEntity<TripProgressResponse> getTripProgress(@PathVariable Long tripId, @AuthenticationPrincipal UserPrincipal principal) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(tripService.getTripProgress(tripId, userId));
     }
 }

--- a/api/src/main/java/com/packit/api/domain/trip/dto/response/TripProgressResponse.java
+++ b/api/src/main/java/com/packit/api/domain/trip/dto/response/TripProgressResponse.java
@@ -1,0 +1,15 @@
+package com.packit.api.domain.trip.dto.response;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+public class TripProgressResponse {
+    private int totalCategoryCount;
+    private int completedCategoryCount;
+    private double progressRate;
+
+    public static TripProgressResponse of(long total, long completed, double rate) {
+        return new TripProgressResponse((int) total, (int) completed, rate);
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/tripCategory/controller/TripCategoryController.java
+++ b/api/src/main/java/com/packit/api/domain/tripCategory/controller/TripCategoryController.java
@@ -3,6 +3,7 @@ package com.packit.api.domain.tripCategory.controller;
 import com.packit.api.common.security.util.SecurityUtils;
 import com.packit.api.domain.tripCategory.dto.request.TripCategoryCreateRequest;
 import com.packit.api.domain.tripCategory.dto.response.TripCategoryResponse;
+import com.packit.api.domain.tripCategory.dto.response.TripCategoryProgressResponse;
 import com.packit.api.domain.tripCategory.entity.TripCategoryStatus;
 import com.packit.api.domain.tripCategory.service.TripCategoryService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -54,5 +55,12 @@ public class TripCategoryController {
         Long userId = SecurityUtils.getCurrentUserId();
         tripCategoryService.delete(id, userId);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "카테고리별 진행률", description = "각 카테고리의 총 항목 수, 완료 수, 진행 상태를 반환합니다.")
+    @GetMapping("/{tripId}/progress/categories")
+    public ResponseEntity<List<TripCategoryProgressResponse>> getCategoryProgress(@PathVariable Long tripId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(tripCategoryService.getCategoryProgress(tripId, userId));
     }
 }

--- a/api/src/main/java/com/packit/api/domain/tripCategory/dto/response/TripCategoryProgressResponse.java
+++ b/api/src/main/java/com/packit/api/domain/tripCategory/dto/response/TripCategoryProgressResponse.java
@@ -1,0 +1,19 @@
+package com.packit.api.domain.tripCategory.dto.response;
+
+import com.packit.api.domain.tripCategory.entity.TripCategory;
+import com.packit.api.domain.tripCategory.entity.TripCategoryStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TripCategoryProgressResponse {
+    private Long tripCategoryId;
+    private String name;
+    private TripCategoryStatus status;
+
+    public static TripCategoryProgressResponse of(TripCategory category) {
+        return new TripCategoryProgressResponse(category.getId(), category.getName(),category.getStatus());
+    }
+}
+

--- a/api/src/main/java/com/packit/api/domain/tripCategory/repository/TripCategoryRepository.java
+++ b/api/src/main/java/com/packit/api/domain/tripCategory/repository/TripCategoryRepository.java
@@ -1,5 +1,6 @@
 package com.packit.api.domain.tripCategory.repository;
 
+import com.packit.api.domain.trip.entity.Trip;
 import com.packit.api.domain.tripCategory.entity.TripCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,4 +8,6 @@ import java.util.List;
 
 public interface TripCategoryRepository extends JpaRepository<TripCategory, Long> {
     List<TripCategory> findAllByTripId(Long tripId);
+
+    List<TripCategory> findAllByTrip(Trip trip);
 }

--- a/api/src/main/java/com/packit/api/domain/tripCategory/service/TripCategoryService.java
+++ b/api/src/main/java/com/packit/api/domain/tripCategory/service/TripCategoryService.java
@@ -5,14 +5,18 @@ import com.packit.api.domain.category.repository.CategoryRepository;
 import com.packit.api.domain.trip.entity.Trip;
 import com.packit.api.domain.trip.repository.TripRepository;
 import com.packit.api.domain.tripCategory.dto.request.TripCategoryCreateRequest;
+import com.packit.api.domain.tripCategory.dto.response.TripCategoryProgressResponse;
 import com.packit.api.domain.tripCategory.dto.response.TripCategoryResponse;
 import com.packit.api.domain.tripCategory.entity.TripCategory;
 import com.packit.api.domain.tripCategory.entity.TripCategoryStatus;
 import com.packit.api.domain.tripCategory.repository.TripCategoryRepository;
+import com.packit.api.domain.tripItem.entity.TripItem;
+import com.packit.api.domain.tripItem.repository.TripItemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +25,7 @@ public class TripCategoryService {
     private final TripRepository tripRepository;
     private final CategoryRepository categoryRepository;
     private final TripCategoryRepository tripCategoryRepository;
+    private final TripItemRepository tripItemRepository;
 
     public TripCategoryResponse create(Long tripId, TripCategoryCreateRequest request, Long userId) {
         Trip trip = getTripOwnedByUser(tripId, userId);
@@ -69,5 +74,14 @@ public class TripCategoryService {
         if (!trip.getUser().getId().equals(userId)) {
             throw new SecurityException("본인의 여행만 접근할 수 있습니다.");
         }
+    }
+
+
+    public List<TripCategoryProgressResponse> getCategoryProgress(Long tripId, Long userId) {
+        Trip trip = getTripOwnedByUser(tripId, userId);
+        List<TripCategory> categories = tripCategoryRepository.findAllByTrip(trip);
+
+        return categories.stream()
+                .map(TripCategoryProgressResponse::of).collect(Collectors.toList());
     }
 }

--- a/api/src/main/java/com/packit/api/domain/tripItem/repository/TripItemRepository.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/repository/TripItemRepository.java
@@ -1,5 +1,6 @@
 package com.packit.api.domain.tripItem.repository;
 
+import com.packit.api.domain.tripCategory.entity.TripCategory;
 import com.packit.api.domain.tripItem.entity.TripItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,4 +8,6 @@ import java.util.List;
 
 public interface TripItemRepository extends JpaRepository<TripItem, Long> {
     List<TripItem> findAllByTripCategoryId(Long tripCategoryId);
+
+    List<TripItem> findAllByTripCategory(TripCategory category);
 }


### PR DESCRIPTION
##  작업 내용
- 여행 진행률(TripProgress) 관련 기능 구현
- TripCategory 진행 상태 계산 로직 추가
- Trip 전체 진행률(%) 계산 API 추가
- TripCategory 진행률 응답 DTO (`TripCategoryProgressResponse`) 정의
- Trip 전체 진행률 응답 DTO (`TripProgressResponse`) 정의
- 진행률 계산 로직 서비스로 분리 (`TripService`, `TripCategoryService`)
- Swagger 문서화 (`@Operation`, `@Parameter` 등 적용)

##  API 명세

| 기능 | Method | URL | 설명 |
|------|--------|-----|------|
| 전체 여행 진행률 조회 | GET | `/api/trips/{tripId}/progress` | 여행 내 모든 카테고리의 완료 상태 기반 진행률(%) 반환 |
| 카테고리별 진행 상태 조회 | GET | `/api/trips/{tripId}/progress/categories` | 각 카테고리별 저장된 항목 수 기반으로 현재 진행 상태 조회 |

## 테스트
- 카테고리별 총 아이템 수 및 임시저장 수 정확히 반영되는지 확인
- 진행률 상태(`NOT_STARTED`, `IN_PROGRESS`, `COMPLETED`) 정확히 반영됨 확인
- Swagger UI에서 요청 및 응답 구조 정상 확인


##  참고 사항
- 진행률 로직은 `TripItem` 변경 시 자동 업데이트 되도록 메서드 분리 (`updateCategoryStatusByItems`)
- TripCategory 상태는 아이템 `isChecked`, `isSaved` 기준으로 동적으로 계산