### PR TITLE
Feat : trip category default copy & 기본 카테고리별 템플릿 아이템 목록 반환

### DIFF
--- a/api/src/main/java/com/packit/api/common/Init/DataInitializer.java
+++ b/api/src/main/java/com/packit/api/common/Init/DataInitializer.java
@@ -1,8 +1,8 @@
 package com.packit.api.common.Init;
 
 import com.packit.api.common.Gender;
-import com.packit.api.domain.TemplateItem.entity.TemplateItem;
-import com.packit.api.domain.TemplateItem.repository.TemplateItemRepository;
+import com.packit.api.domain.templateItem.entity.TemplateItem;
+import com.packit.api.domain.templateItem.repository.TemplateItemRepository;
 import com.packit.api.domain.category.entity.Category;
 import com.packit.api.domain.category.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;

--- a/api/src/main/java/com/packit/api/domain/TemplateItem/repository/TemplateItemRepository.java
+++ b/api/src/main/java/com/packit/api/domain/TemplateItem/repository/TemplateItemRepository.java
@@ -1,6 +1,0 @@
-package com.packit.api.domain.TemplateItem.repository;
-
-import com.packit.api.domain.TemplateItem.entity.TemplateItem;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface TemplateItemRepository extends JpaRepository<TemplateItem, Long> {}

--- a/api/src/main/java/com/packit/api/domain/templateItem/controller/TemplateItemController.java
+++ b/api/src/main/java/com/packit/api/domain/templateItem/controller/TemplateItemController.java
@@ -1,0 +1,30 @@
+package com.packit.api.domain.templateItem.controller;
+
+import com.packit.api.domain.templateItem.dto.TemplateItemResponse;
+import com.packit.api.domain.templateItem.service.TemplateItemService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "TemplateItem", description = "카테고리별 템플릿 아이템 조회 API")
+@RestController
+@RequestMapping("/api/template-items")
+@RequiredArgsConstructor
+public class TemplateItemController {
+
+    private final TemplateItemService templateItemService;
+
+    @Operation(summary = "카테고리별 템플릿 아이템 조회", description = "선택한 카테고리(categoryId)의 템플릿 아이템 목록을 반환합니다.")
+    @GetMapping
+    public ResponseEntity<List<TemplateItemResponse>> getTemplateItems(
+            @Parameter(description = "카테고리 ID", required = true)
+            @RequestParam Long categoryId
+    ) {
+        return ResponseEntity.ok(templateItemService.findByCategory(categoryId));
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/templateItem/dto/TemplateItemResponse.java
+++ b/api/src/main/java/com/packit/api/domain/templateItem/dto/TemplateItemResponse.java
@@ -1,0 +1,28 @@
+package com.packit.api.domain.templateItem.dto;
+
+import com.packit.api.common.Gender;
+import com.packit.api.domain.templateItem.entity.TemplateItem;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class TemplateItemResponse {
+
+    @Schema(description = "템플릿 아이템 ID")
+    private Long id;
+
+    @Schema(description = "템플릿 아이템 이름")
+    private String name;
+
+    @Schema(description = "기본 수량")
+    private int defaultQuantity;
+
+    @Schema(description = "대상 성별")
+    private Gender gender;
+
+    public static TemplateItemResponse from(TemplateItem item) {
+        return of(item.getId(), item.getName(), item.getDefaultQuantity(), item.getGender());
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/templateItem/entity/TemplateItem.java
+++ b/api/src/main/java/com/packit/api/domain/templateItem/entity/TemplateItem.java
@@ -1,4 +1,4 @@
-package com.packit.api.domain.TemplateItem.entity;
+package com.packit.api.domain.templateItem.entity;
 
 import com.packit.api.common.Gender;
 import com.packit.api.domain.category.entity.Category;

--- a/api/src/main/java/com/packit/api/domain/templateItem/repository/TemplateItemRepository.java
+++ b/api/src/main/java/com/packit/api/domain/templateItem/repository/TemplateItemRepository.java
@@ -1,0 +1,11 @@
+package com.packit.api.domain.templateItem.repository;
+
+import com.packit.api.domain.templateItem.entity.TemplateItem;
+import com.packit.api.domain.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TemplateItemRepository extends JpaRepository<TemplateItem, Long> {
+    List<TemplateItem> findAllByCategory(Category category);
+}

--- a/api/src/main/java/com/packit/api/domain/templateItem/service/TemplateItemService.java
+++ b/api/src/main/java/com/packit/api/domain/templateItem/service/TemplateItemService.java
@@ -1,0 +1,29 @@
+package com.packit.api.domain.templateItem.service;
+
+import com.packit.api.domain.category.entity.Category;
+import com.packit.api.domain.category.repository.CategoryRepository;
+import com.packit.api.domain.templateItem.dto.TemplateItemResponse;
+import com.packit.api.domain.templateItem.entity.TemplateItem;
+import com.packit.api.domain.templateItem.repository.TemplateItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TemplateItemService {
+
+    private final TemplateItemRepository templateItemRepository;
+    private final CategoryRepository categoryRepository;
+
+    public List<TemplateItemResponse> findByCategory(Long categoryId) {
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 카테고리가 존재하지 않습니다. id=" + categoryId));
+        List<TemplateItem> items = templateItemRepository.findAllByCategory(category);
+        return items.stream()
+                .map(TemplateItemResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/trip/service/TripInitializerService.java
+++ b/api/src/main/java/com/packit/api/domain/trip/service/TripInitializerService.java
@@ -1,0 +1,31 @@
+package com.packit.api.domain.trip.service;
+
+import com.packit.api.domain.templateItem.repository.TemplateItemRepository;
+import com.packit.api.domain.category.entity.Category;
+import com.packit.api.domain.category.repository.CategoryRepository;
+import com.packit.api.domain.trip.entity.Trip;
+import com.packit.api.domain.tripCategory.entity.TripCategory;
+import com.packit.api.domain.tripCategory.repository.TripCategoryRepository;
+import com.packit.api.domain.tripItem.repository.TripItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TripInitializerService {
+
+    private final CategoryRepository categoryRepository;
+    private final TemplateItemRepository templateItemRepository;
+    private final TripCategoryRepository tripCategoryRepository;
+    private final TripItemRepository tripItemRepository;
+
+    public void initializeDefaultsFor(Trip trip) {
+        List<Category> categories = categoryRepository.findAll();
+        for (Category category : categories) {
+            TripCategory tripCategory = TripCategory.of(trip, category, category.getName());
+            tripCategoryRepository.save(tripCategory);
+        }
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/trip/service/TripService.java
+++ b/api/src/main/java/com/packit/api/domain/trip/service/TripService.java
@@ -15,6 +15,7 @@ import com.packit.api.domain.user.entity.User;
 import com.packit.api.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -27,14 +28,18 @@ public class TripService {
     private final TripRepository tripRepository;
     private final TripCategoryRepository tripCategoryRepository;
     private final TripItemRepository tripItemRepository;
+    private final TripInitializerService tripInitializerService;
 
+    @Transactional
     public TripResponse createTrip(TripCreateRequest request) {
         Long userId = SecurityUtils.getCurrentUserId();
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
         Trip trip = Trip.of(user, request);
-        tripRepository.save(trip);
+        Trip savedTrip = tripRepository.save(trip);
+
+        tripInitializerService.initializeDefaultsFor(savedTrip);
 
         return TripResponse.from(trip);
     }

--- a/api/src/main/java/com/packit/api/domain/tripItem/entity/TripItem.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/entity/TripItem.java
@@ -1,6 +1,7 @@
 package com.packit.api.domain.tripItem.entity;
 
 import com.packit.api.common.BaseTimeEntity;
+import com.packit.api.domain.templateItem.entity.TemplateItem;
 import com.packit.api.domain.tripCategory.entity.TripCategory;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/api/src/main/java/com/packit/api/domain/tripItem/service/TripItemService.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/service/TripItemService.java
@@ -1,7 +1,7 @@
 package com.packit.api.domain.tripItem.service;
 
-import com.packit.api.domain.TemplateItem.entity.TemplateItem;
-import com.packit.api.domain.TemplateItem.repository.TemplateItemRepository;
+import com.packit.api.domain.templateItem.entity.TemplateItem;
+import com.packit.api.domain.templateItem.repository.TemplateItemRepository;
 import com.packit.api.domain.tripCategory.entity.TripCategory;
 import com.packit.api.domain.tripCategory.repository.TripCategoryRepository;
 import com.packit.api.domain.tripCategory.service.TripCategoryService;


### PR DESCRIPTION
##  작업 내용
- TripCategoryService에 `initializeDefaultsFor(Trip trip)` 메서드 추가
  - 기본 제공 Category 전체 조회
  - 각 Category 기반 TripCategory 생성 및 저장
  - 해당 카테고리의 TemplateItem들을 TripItem으로 변환하여 저장
- TripService 내부 Trip 생성 시 위 초기화 로직 연동
- TemplateItemController 및 TemplateItemService 구현
  - 특정 Category에 속한 TemplateItem 목록 조회 API (`GET /api/template-items`)
- TemplateItemResponse DTO 정의 (id, name, quantity, gender 반환)
- Swagger 문서화 (@Operation, @Parameter) 적용

##  API 명세
| 기능 | Method | URL | 설명 |
|------|--------|-----|------|
| 여행 생성 시 기본 항목 자동 추가 | POST | `/api/trips` | 여행 생성 시 Category 및 TemplateItem 자동 복사 |
| 템플릿 아이템 목록 조회 | GET | `/api/template-items?categoryId={id}` | 기본 카테고리별 템플릿 아이템 목록 반환 |

## 테스트
- Trip 생성 시 각 TripCategory 및 TripItem이 정상적으로 생성되는지 확인 (DB 확인)
- Swagger UI에서 템플릿 아이템 조회 API 테스트
- 유효하지 않은 categoryId 요청 시 예외 처리 확인

##  참고 사항
- Trip 생성 시 자동 생성된 TripCategory, TripItem은 사용자에 의해 수정/삭제 가능
- 추후 사용자가 선택한 TemplateItem만 TripItem으로 복사하도록 개선 예정
- TemplateItemResponse에 Enum(Gender) 한글 표시(displayName) 추가 가능
