### PR TITLE
chore: Spring Boot Dockerfile 구성 및 GCE 배포 

### DIFF
--- a/api/src/main/java/com/packit/api/common/security/controller/AuthController.java
+++ b/api/src/main/java/com/packit/api/common/security/controller/AuthController.java
@@ -19,10 +19,12 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Tag(name = "Auth API")
+@RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/api/src/main/java/com/packit/api/domain/user/controller/UserJoinController.java
+++ b/api/src/main/java/com/packit/api/domain/user/controller/UserJoinController.java
@@ -10,7 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping(value = "/users")
+@RequestMapping(value = "/api/users")
 @Tag(name = "User Join API", description = "회원가입 API")
 @RequiredArgsConstructor
 public class UserJoinController {

--- a/api/src/main/resources/application-prod.yml
+++ b/api/src/main/resources/application-prod.yml
@@ -1,0 +1,26 @@
+# 이름 : application-local.yml
+# 로컬 환경에서 사용할 설정 파일
+# redis와 mysql 로컬 환경에서 사용할 설정
+# 기본적으로 DB는 localhost에 연결
+spring:
+    datasource:
+        url: jdbc:mysql://${DB_HOST}:3306/packet_db
+        username: ${DB_USER}
+        password: ${DB_PASS}
+
+    jpa:
+        hibernate:
+            ddl-auto: update
+        properties:
+            hibernate:
+                dialect: org.hibernate.dialect.MySQL8Dialect
+                format_sql: true
+                show_sql: true
+
+    data:
+        redis:
+            host: ${REDIS_HOST}
+            port: ${REDIS_PORT}
+
+swagger:
+    base-url: http://${SWAGGER_BASE_URL}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
     application:
         name: api
     profiles:
-        active: local # local, dev (?? ?? ?? dev? ??)
+        active: prod # local, dev (?? ?? ?? dev? ??)
         include: jwt  # JWT, AWS, LOGIN, OAUTH2
     servlet:
         multipart:

--- a/docker/Dockerfile_Spring
+++ b/docker/Dockerfile_Spring
@@ -1,0 +1,5 @@
+# docker/Dockerfile_Spring
+FROM openjdk:17
+WORKDIR /app
+COPY ./api/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## PR 제목
chore: Spring Boot Dockerfile 구성 및 GCE 배포 자동화 연동

---

## 주요 변경 사항 (What I did)

- Spring Boot용 Dockerfile 작성 (Dockerfile_Spring)
  - Gradle build 결과 JAR 기반 도커 이미지 구성
  - openjdk:17 기반, app.jar 실행

- 도커 이미지 빌드 및 DockerHub 푸시 연동
  -  ./gradlew build → docker build → docker push

- .env.prod 템플릿 및 GCE VM 내 자동 생성
  - JWT, DB, Redis 설정을 포함한 .env.prod 자동 주입

---

## 주요 파일

| 파일 경로 | 설명 |
|-----------|------|
| docker/Dockerfile_Spring | Spring Boot 도커 이미지 정의 |
| .github/workflows/deploy.yml | CI/CD 자동화 GitHub Actions 워크플로우 |
| scripts/spring-setup.tpl.sh | GCE VM에서 .env.prod 생성 및 Docker 실행 스크립트 |

---

## 테스트

- ./gradlew clean build 성공
- 로컬 도커 이미지 빌드 및 DockerHub 푸시 확인
- GCE VM 내 .env.prod 정상 생성
- 도커 컨테이너 실행 및 로그 확인
- Nginx Reverse Proxy + Swagger UI 정상 동작 확인

---

## 기타 참고 사항

- Terraform으로 Cloud SQL, Redis, VM 등 GCP 인프라 자동 구성
- DB 접속 오류는 authorized_networks 설정으로 해결
- 향후 GCR, Secret Manager로 전환 여지 있음
- .env.prod 파일 내용은 GitHub Actions 또는 SSH Script에서 자동 주입됨