### PR TITLE
Fix: cascade trip delete

### DIFF
--- a/api/src/main/java/com/packit/api/domain/trip/entity/Trip.java
+++ b/api/src/main/java/com/packit/api/domain/trip/entity/Trip.java
@@ -3,6 +3,7 @@ package com.packit.api.domain.trip.entity;
 import com.packit.api.common.BaseTimeEntity;
 import com.packit.api.domain.trip.dto.request.TripCreateRequest;
 import com.packit.api.domain.trip.dto.request.TripUpdateRequest;
+import com.packit.api.domain.tripCategory.entity.TripCategory;
 import com.packit.api.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -11,6 +12,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -36,6 +39,9 @@ public class Trip extends BaseTimeEntity {
     private String description;
 
     private boolean isCompleted;
+
+    @OneToMany(mappedBy = "trip", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<TripCategory> tripCategories = new ArrayList<>();
 
     @Builder
     private Trip(User user, String title, String region, TripType tripType,

--- a/api/src/main/java/com/packit/api/domain/tripCategory/entity/TripCategory.java
+++ b/api/src/main/java/com/packit/api/domain/tripCategory/entity/TripCategory.java
@@ -3,11 +3,15 @@ package com.packit.api.domain.tripCategory.entity;
 import com.packit.api.common.BaseTimeEntity;
 import com.packit.api.domain.category.entity.Category;
 import com.packit.api.domain.trip.entity.Trip;
+import com.packit.api.domain.tripItem.entity.TripItem;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -18,6 +22,7 @@ public class TripCategory extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id")
     private Trip trip;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/api/src/main/java/com/packit/api/domain/tripCategory/entity/TripCategory.java
+++ b/api/src/main/java/com/packit/api/domain/tripCategory/entity/TripCategory.java
@@ -25,6 +25,10 @@ public class TripCategory extends BaseTimeEntity {
     @JoinColumn(name = "trip_id")
     private Trip trip;
 
+    @OneToMany(mappedBy = "tripCategory", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<TripItem> tripItems = new ArrayList<>();
+
+
     @ManyToOne(fetch = FetchType.LAZY)
     private Category category; // nullable
 

--- a/api/src/main/java/com/packit/api/domain/tripItem/entity/TripItem.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/entity/TripItem.java
@@ -1,7 +1,6 @@
 package com.packit.api.domain.tripItem.entity;
 
 import com.packit.api.common.BaseTimeEntity;
-import com.packit.api.domain.templateItem.entity.TemplateItem;
 import com.packit.api.domain.tripCategory.entity.TripCategory;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -19,6 +18,7 @@ public class TripItem extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_category_id")
     private TripCategory tripCategory;
 
     private String name;


### PR DESCRIPTION
## 작업 내용
- TripCategory → TripItem 연관 관계에 `cascade = REMOVE`, `orphanRemoval = true` 설정 추가
- Trip →TripCategory 연관 관계에 `cascade = REMOVE`, `orphanRemoval = true` 설정 추가
- Trip 삭제 시 TripCategory 및 TripItem까지 연쇄 삭제되도록 수정
- TripItem의 외래키 제약 오류 (`Cannot delete or update a parent row`) 해결
- TripCategory 엔티티에 TripItem 리스트 필드 추가

## 🔧 연관 관계 구성 요약
| 엔티티 | 연관 대상 | 연관 관계 | 삭제 시 |
|--------|-----------|-----------|---------|
| Trip | TripCategory | `@OneToMany(cascade = REMOVE)` | TripCategory 자동 삭제 |
| TripCategory | TripItem | `@OneToMany(cascade = REMOVE, orphanRemoval = true)` | TripItem 자동 삭제 |

## 테스트
- Trip 삭제 시 TripCategory 및 TripItem 모두 정상 삭제됨 확인
- 외래키 제약으로 인한 404 오류 재현 및 수정 전후 비교 검증
- Swagger를 통해 Trip 삭제 API 정상 응답 (`200 OK`) 확인

## 참고 사항
- TripCategory에서 TripItem으로의 연관 삭제가 명확히 동작하지 않아, `cascade` 및 `orphanRemoval` 설정
- Trip → TripCategory -> TripItem 연쇄 삭제
