### PR TITLE
feat: TripItem 생성 API 구현 (템플릿 여부 무관 단순 JSON 리스트 기반)

### DIFF
--- a/api/gradlew
+++ b/api/gradlew
@@ -86,7 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
+APP_HOME=$( cd "${APP_HOME:-./}" > /dev/null && pwd -P ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum
@@ -114,7 +114,7 @@ case "$( uname )" in                #(
   NONSTOP* )        nonstop=true ;;
 esac
 
-CLASSPATH="\\\"\\\""
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
 
 # Determine the Java command to use to start the JVM.
@@ -205,7 +205,7 @@ fi
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
 # Collect all arguments for the java command:
-#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
 #     and any embedded shellness will be escaped.
 #   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
 #     treated as '${Hostname}' itself on the command line.
@@ -213,7 +213,7 @@ DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \
         -classpath "$CLASSPATH" \
-        -jar "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" \
+        org.gradle.wrapper.GradleWrapperMain \
         "$@"
 
 # Stop when "xargs" is not available.

--- a/api/gradlew.bat
+++ b/api/gradlew.bat
@@ -13,8 +13,6 @@
 @rem See the License for the specific language governing permissions and
 @rem limitations under the License.
 @rem
-@rem SPDX-License-Identifier: Apache-2.0
-@rem
 
 @if "%DEBUG%"=="" @echo off
 @rem ##########################################################################
@@ -70,11 +68,11 @@ goto fail
 :execute
 @rem Setup the command line
 
-set CLASSPATH=
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" -jar "%APP_HOME%\gradle\wrapper\gradle-wrapper.jar" %*
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/api/src/main/java/com/packit/api/domain/tripCategory/repository/TripCategoryRepository.java
+++ b/api/src/main/java/com/packit/api/domain/tripCategory/repository/TripCategoryRepository.java
@@ -5,9 +5,12 @@ import com.packit.api.domain.tripCategory.entity.TripCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TripCategoryRepository extends JpaRepository<TripCategory, Long> {
     List<TripCategory> findAllByTripId(Long tripId);
 
     List<TripCategory> findAllByTrip(Trip trip);
+
+    Optional<TripCategory> findByIdAndTripId(Long tripCategoryId, Long tripId);
 }

--- a/api/src/main/java/com/packit/api/domain/tripItem/controller/TripItemController.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/controller/TripItemController.java
@@ -3,9 +3,11 @@ package com.packit.api.domain.tripItem.controller;
 import com.packit.api.common.security.util.SecurityUtils;
 import com.packit.api.domain.tripItem.dto.request.TripItemCreateRequest;
 import com.packit.api.domain.tripItem.dto.request.TripItemFromTemplateRequest;
+import com.packit.api.domain.tripItem.dto.request.TripItemListCreateRequest;
 import com.packit.api.domain.tripItem.dto.response.TripItemResponse;
 import com.packit.api.domain.tripItem.service.TripItemService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -72,4 +74,18 @@ public class TripItemController {
         tripItemService.addItemsFromTemplate(tripCategoryId, request.templateItemIds(), userId);
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "TripItem 생성",
+            description = "기본템플릿이든 사용자 입력이든, name/quantity/memo만 포함된 단순 리스트를 기반으로 TripItem 생성")
+    @PostMapping("/trips/{tripId}/categories/{tripCategoryId}/items")
+    public ResponseEntity<Void> createTripItems(
+            @Parameter(description = "여행 ID") @PathVariable Long tripId,
+            @Parameter(description = "여행 카테고리 ID") @PathVariable Long tripCategoryId,
+            @RequestBody TripItemListCreateRequest request
+    ) {
+        tripItemService.createItems(tripId, tripCategoryId, request);
+        return ResponseEntity.ok().build();
+    }
+
+
 }

--- a/api/src/main/java/com/packit/api/domain/tripItem/dto/request/TripItemCreateRequest.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/dto/request/TripItemCreateRequest.java
@@ -1,7 +1,16 @@
 package com.packit.api.domain.tripItem.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
 public record TripItemCreateRequest(
+        @NotBlank
+        @Schema(description = "아이템 이름", example = "양말")
         String name,
+
+        @Schema(description = "수량", example = "3")
         Integer quantity,
+
+        @Schema(description = "메모", example = "겨울용")
         String memo
 ) {}

--- a/api/src/main/java/com/packit/api/domain/tripItem/dto/request/TripItemListCreateRequest.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/dto/request/TripItemListCreateRequest.java
@@ -1,0 +1,17 @@
+package com.packit.api.domain.tripItem.dto.request;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(staticName = "of")
+@Builder
+public class TripItemListCreateRequest {
+
+    @Schema(description = "추가할 아이템 리스트", required = true)
+    private List<TripItemCreateRequest> items;
+}

--- a/api/src/main/java/com/packit/api/domain/tripItem/service/TripItemService.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/service/TripItemService.java
@@ -6,6 +6,7 @@ import com.packit.api.domain.tripCategory.entity.TripCategory;
 import com.packit.api.domain.tripCategory.repository.TripCategoryRepository;
 import com.packit.api.domain.tripCategory.service.TripCategoryService;
 import com.packit.api.domain.tripItem.dto.request.TripItemCreateRequest;
+import com.packit.api.domain.tripItem.dto.request.TripItemListCreateRequest;
 import com.packit.api.domain.tripItem.dto.response.TripItemResponse;
 import com.packit.api.domain.tripItem.entity.TripItem;
 import com.packit.api.domain.tripItem.repository.TripItemRepository;
@@ -114,6 +115,25 @@ public class TripItemService {
             category.updateStatus(COMPLETED);
         } else {
             category.updateStatus(IN_PROGRESS);
+        }
+    }
+
+    public void createItems(Long tripId, Long tripCategoryId, TripItemListCreateRequest request) {
+        TripCategory tripCategory = tripCategoryRepository.findByIdAndTripId(tripCategoryId, tripId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 TripCategory가 존재하지 않습니다."));
+
+        for (TripItemCreateRequest item : request.getItems()) {
+            TripItem tripItem = TripItem.builder()
+                    .tripCategory(tripCategory)
+                    .name(item.name())
+                    .quantity(item.quantity() != null ? item.quantity() : 1)
+                    .memo(item.memo())
+                    .isChecked(false)
+                    .isSaved(true)
+                    .isAiGenerated(false) // 추후 AI 생성이면 true
+                    .build();
+
+            tripItemRepository.save(tripItem);
         }
     }
 }


### PR DESCRIPTION
## 📌 작업 내용 요약

- TripCategory 하위에 TripItem을 생성하는 API 구현
- 템플릿 여부 무관하게 단순 JSON 구조로 요청 받음

```json
{
  "items": [
    { "name": "양말", "quantity": 3, "memo": "겨울용" },
    { "name": "속옷", "quantity": 2 },
    { "name": "면티" }
  ]
}
```
- quantity, memo는 선택 항목
- quantity 미지정 시 기본값 1 처리
- 저장 시 기본 상태:
	 - isSaved = true
	 - isChecked = false
	 - isAiGenerated = false
