### PR TITLE
refactor: 반복 저장 대신 saveAll() 적용 , 정적팩토리 메서드 적용

### DIFF
--- a/api/src/main/java/com/packit/api/domain/tripItem/controller/TripItemController.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/controller/TripItemController.java
@@ -83,7 +83,7 @@ public class TripItemController {
             @Parameter(description = "여행 카테고리 ID") @PathVariable Long tripCategoryId,
             @RequestBody TripItemListCreateRequest request
     ) {
-        tripItemService.createItems(tripId, tripCategoryId, request);
+        tripItemService.createBulkItems(tripId, tripCategoryId, request);
         return ResponseEntity.ok().build();
     }
 

--- a/api/src/main/java/com/packit/api/domain/tripItem/entity/TripItem.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/entity/TripItem.java
@@ -57,6 +57,18 @@ public class TripItem extends BaseTimeEntity {
                 .build();
     }
 
+    public static TripItem of(TripCategory tripCategory, String name, Integer quantity, String memo) {
+        return TripItem.builder()
+                .tripCategory(tripCategory)
+                .name(name)
+                .quantity(quantity)
+                .memo(memo)
+                .isChecked(false)
+                .isSaved(true)
+                .isAiGenerated(false)
+                .build();
+    }
+
     public void toggleCheck() {
         this.isChecked = !this.isChecked;
     }

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
     application:
         name: api
     profiles:
-        active: prod # local, dev (?? ?? ?? dev? ??)
+        active: local # local, dev (?? ?? ?? dev? ??)
         include: jwt  # JWT, AWS, LOGIN, OAUTH2
     servlet:
         multipart:


### PR DESCRIPTION
# 🚀 feat/TripItemBulkCreate - TripItem 다중 생성 API 추가

## 📌 개요
- TripCategory 내 여러 개의 짐 항목(TripItem)을 한 번에 생성하는 기능 추가
- 템플릿 기반이든 사용자 정의든 동일한 방식으로 생성할 수 있도록 설계
- Swagger 문서화 포함

---

## 🔧 주요 구현 내용

- `TripItemCreateRequest` (record):
  - 필드: `name (필수)`, `quantity (선택)`, `memo (선택)`
  - Swagger 예시와 설명 포함

- `TripItemListCreateRequest` (class):
  - 필드: `List<TripItemCreateRequest> items`
  - `@Schema` 문서화 및 validation

- `TripItemService#createItems()`:
  - 입력 받은 JSON 리스트 기반으로 TripItem을 생성
  - `TripCategory` 존재 여부 확인
  - `quantity`가 null인 경우 기본값 `1` 설정
  - `TripItem.of(tripCategory, name, quantity, memo)` 정적 팩토리 메소드 사용
  - `tripItemRepository.saveAll()`으로 일괄 저장 처리

- `TripItem.of(...)` 오버로드 추가:
  - 기존: `(TripCategory, String, Integer)`
  - 신규: `(TripCategory, String, Integer, String)` → memo 포함

---

##  고려사항 및 처리

- 이름 중복 체크는 서버 단에서 별도로 처리하지 않음 (동일 이름 허용)
- 템플릿 기반 여부 추적은 하지 않음 (`isAiGenerated = false`로 고정)
- 향후 AI 추천 기반 생성 시 `isAiGenerated`만 true로 설정하면 구조 유지됨

---

##  Swagger 문서화

- `@Operation(summary = "짐 항목 다중 생성")`
- `@RequestBody` 예시:
```json
{
  "items": [
    {
      "name": "양말",
      "quantity": 3,
      "memo": "겨울용"
    },
    {
      "name": "속옷",
      "quantity": 2
    },
    {
      "name": "면티"
    }
  ]
}