### PR TITLE
refactor: 응답 포맷 통일 리팩토링

### DIFF
--- a/api/src/main/java/com/packit/api/domain/templateItem/controller/TemplateItemController.java
+++ b/api/src/main/java/com/packit/api/domain/templateItem/controller/TemplateItemController.java
@@ -1,5 +1,6 @@
 package com.packit.api.domain.templateItem.controller;
 
+import com.packit.api.common.response.ListResponse;
 import com.packit.api.domain.templateItem.dto.TemplateItemResponse;
 import com.packit.api.domain.templateItem.service.TemplateItemService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,10 +26,11 @@ public class TemplateItemController {
             description = "선택한 카테고리(categoryId)의 템플릿 아이템 목록을 반환합니다."
     )
     @GetMapping("/categories/{categoryId}/template-items")
-    public ResponseEntity<List<TemplateItemResponse>> getTemplateItems(
+    public ResponseEntity<ListResponse<TemplateItemResponse>> getTemplateItems(
             @Parameter(description = "카테고리 ID", required = true, example = "1")
             @PathVariable Long categoryId
     ) {
-        return ResponseEntity.ok(templateItemService.findByCategory(categoryId));
+        List<TemplateItemResponse> items = templateItemService.findByCategory(categoryId);
+        return ResponseEntity.ok(new ListResponse<>(200, "템플릿 아이템 조회 완료", items));
     }
 }

--- a/api/src/main/java/com/packit/api/domain/trip/controller/TripController.java
+++ b/api/src/main/java/com/packit/api/domain/trip/controller/TripController.java
@@ -1,5 +1,7 @@
 package com.packit.api.domain.trip.controller;
 
+import com.packit.api.common.response.ListResponse;
+import com.packit.api.common.response.SingleResponse;
 import com.packit.api.common.security.util.SecurityUtils;
 import com.packit.api.domain.trip.dto.request.TripCreateRequest;
 import com.packit.api.domain.trip.dto.request.TripUpdateRequest;
@@ -32,54 +34,59 @@ public class TripController {
             description = "여행 제목, 지역, 시작일/종료일, 유형, 설명을 입력받아 새로운 여행을 생성합니다."
     )
     @PostMapping
-    public ResponseEntity<TripResponse> createTrip(
+    public ResponseEntity<SingleResponse<TripResponse>> createTrip(
             @RequestBody @Valid TripCreateRequest request) {
         TripResponse response = tripService.createTrip(request);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(new SingleResponse<>(200, "여행 생성 완료", response));
     }
 
     @Operation(summary = "내 여행 목록 조회", description = "로그인한 사용자의 전체 여행 목록을 조회합니다.")
     @GetMapping
-    public ResponseEntity<List<TripResponse>> getTripList() {
+    public ResponseEntity<ListResponse<TripResponse>> getTripList() {
         Long userId = SecurityUtils.getCurrentUserId();
-        return ResponseEntity.ok(tripService.getTripList(userId));
+        List<TripResponse> trips = tripService.getTripList(userId);
+        return ResponseEntity.ok(new ListResponse<>(200, "내 여행 목록 조회 완료", trips));
     }
 
     @Operation(summary = "여행 상세 조회", description = "여행 ID에 해당하는 상세 정보를 조회합니다.")
 
     @GetMapping("/{id}")
-    public ResponseEntity<TripResponse> getTripDetail(
+    public ResponseEntity<SingleResponse<TripResponse>> getTripDetail(
             @Parameter(name = "id", description = "조회할 여행 ID", required = true)
             @PathVariable Long id) {
         Long userId = SecurityUtils.getCurrentUserId();
-        return ResponseEntity.ok(tripService.getTripDetail(id, userId));
+        TripResponse detail = tripService.getTripDetail(id, userId);
+        return ResponseEntity.ok(new SingleResponse<>(200, "여행 상세 조회 완료", detail));
     }
+
 
     @Operation(summary = "여행 수정", description = "여행 ID에 해당하는 여행 정보를 수정합니다.")
     @PatchMapping("/{tripId}")
-    public ResponseEntity<TripResponse> updateTrip(
+    public ResponseEntity<SingleResponse<TripResponse>> updateTrip(
             @Parameter(name = "tripId", description = "수정할 여행 ID", required = true)
             @PathVariable Long tripId,
             @Parameter(name = "request", description = "수정할 여행 정보", required = true)
             @RequestBody @Valid TripUpdateRequest request) {
         Long userId = SecurityUtils.getCurrentUserId();
-        return ResponseEntity.ok(tripService.updateTrip(tripId, userId, request));
+        TripResponse updated = tripService.updateTrip(tripId, userId, request);
+        return ResponseEntity.ok(new SingleResponse<>(200, "여행 수정 완료", updated));
     }
 
     @Operation(summary = "여행 삭제", description = "여행 ID에 해당하는 여행을 삭제합니다.")
     @DeleteMapping("/{tripId}")
-    public ResponseEntity<Void> deleteTrip(
+    public ResponseEntity<SingleResponse<String>> deleteTrip(
             @Parameter(name = "tripId", description = "삭제할 여행 ID", required = true)
             @PathVariable Long tripId) {
         Long userId = SecurityUtils.getCurrentUserId();
         tripService.deleteTrip(tripId, userId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(new SingleResponse<>(200, "여행 삭제 완료", "success"));
     }
 
     @Operation(summary = "전체 짐싸기 진행률 조회", description = "여행 내 전체 카테고리의 짐싸기 완료 상태를 기반으로 진행률을 반환합니다.")
     @GetMapping("/{tripId}/progress")
-    public ResponseEntity<TripProgressResponse> getTripProgress(@PathVariable Long tripId) {
+    public ResponseEntity<SingleResponse<TripProgressResponse>> getTripProgress(@PathVariable Long tripId) {
         Long userId = SecurityUtils.getCurrentUserId();
-        return ResponseEntity.ok(tripService.getTripProgress(tripId, userId));
+        TripProgressResponse progress = tripService.getTripProgress(tripId, userId);
+        return ResponseEntity.ok(new SingleResponse<>(200, "짐싸기 진행률 조회 완료", progress));
     }
 }

--- a/api/src/main/java/com/packit/api/domain/tripCategory/controller/TripCategoryController.java
+++ b/api/src/main/java/com/packit/api/domain/tripCategory/controller/TripCategoryController.java
@@ -1,5 +1,7 @@
 package com.packit.api.domain.tripCategory.controller;
 
+import com.packit.api.common.response.ListResponse;
+import com.packit.api.common.response.SingleResponse;
 import com.packit.api.common.security.util.SecurityUtils;
 import com.packit.api.domain.tripCategory.dto.request.TripCategoryCreateRequest;
 import com.packit.api.domain.tripCategory.dto.request.TripCategoryStatusUpdateRequest;
@@ -26,43 +28,46 @@ public class TripCategoryController {
 
     @Operation(summary = "여행에 카테고리 추가", description = "여행(tripId)에 새로운 카테고리를 추가합니다. 기본 제공 카테고리 또는 사용자 정의 이름을 기반으로 생성할 수 있습니다.")
     @PostMapping("/trips/{tripId}/trip-categories")
-    public ResponseEntity<TripCategoryResponse> createCategory(
+    public ResponseEntity<SingleResponse<TripCategoryResponse>> createCategory(
             @PathVariable Long tripId,
             @RequestBody @Valid TripCategoryCreateRequest request) {
         Long userId = SecurityUtils.getCurrentUserId();
-        return ResponseEntity.ok(tripCategoryService.create(tripId, request, userId));
+        TripCategoryResponse response = tripCategoryService.create(tripId, request, userId);
+        return ResponseEntity.ok(new SingleResponse<>(200, "카테고리 생성 완료", response));
     }
 
     @Operation(summary = "여행별 카테고리 목록 조회", description = "해당 tripId에 속한 모든 TripCategory를 조회합니다.")
     @GetMapping("/trips/{tripId}/trip-categories")
-    public ResponseEntity<List<TripCategoryResponse>> getCategories(@PathVariable Long tripId) {
+    public ResponseEntity<ListResponse<TripCategoryResponse>> getCategories(@PathVariable Long tripId) {
         Long userId = SecurityUtils.getCurrentUserId();
-        return ResponseEntity.ok(tripCategoryService.getTripCategories(tripId, userId));
+        List<TripCategoryResponse> list = tripCategoryService.getTripCategories(tripId, userId);
+        return ResponseEntity.ok(new ListResponse<>(200, "카테고리 목록 조회 완료", list));
     }
 
     @Operation(summary = "카테고리 상태 변경", description = "짐싸기 상태(NOT_STARTED, IN_PROGRESS, COMPLETED)를 변경합니다.")
     @PatchMapping("/trip-categories/{tripCategoryId}")
-    public ResponseEntity<Void> updateStatus(
+    public ResponseEntity<SingleResponse<String>> updateStatus(
             @PathVariable Long tripCategoryId,
             @RequestBody @Valid TripCategoryStatusUpdateRequest request
     ) {
         Long userId = SecurityUtils.getCurrentUserId();
         tripCategoryService.updateStatus(tripCategoryId, request.getStatus(), userId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(new SingleResponse<>(200, "카테고리 상태 수정 완료", "success"));
     }
 
     @Operation(summary = "카테고리 삭제", description = "해당 TripCategory를 삭제합니다.")
     @DeleteMapping("/trip-categories/{tripCategoryId}")
-    public ResponseEntity<Void> deleteCategory(@PathVariable Long tripCategoryId) {
+    public ResponseEntity<SingleResponse<String>> deleteCategory(@PathVariable Long tripCategoryId) {
         Long userId = SecurityUtils.getCurrentUserId();
         tripCategoryService.delete(tripCategoryId, userId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(new SingleResponse<>(200, "카테고리 삭제 완료", "success"));
     }
 
     @Operation(summary = "카테고리별 진행률", description = "여행에 포함된 각 카테고리의 진행률(전체 항목 수, 완료 수 등)을 반환합니다.")
     @GetMapping("/trips/{tripId}/trip-categories/progress")
-    public ResponseEntity<List<TripCategoryProgressResponse>> getCategoryProgress(@PathVariable Long tripId) {
+    public ResponseEntity<ListResponse<TripCategoryProgressResponse>> getCategoryProgress(@PathVariable Long tripId) {
         Long userId = SecurityUtils.getCurrentUserId();
-        return ResponseEntity.ok(tripCategoryService.getCategoryProgress(tripId, userId));
+        List<TripCategoryProgressResponse> progressList = tripCategoryService.getCategoryProgress(tripId, userId);
+        return ResponseEntity.ok(new ListResponse<>(200, "카테고리 진행률 조회 완료", progressList));
     }
 }

--- a/api/src/main/java/com/packit/api/domain/tripItem/controller/TripItemController.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/controller/TripItemController.java
@@ -1,5 +1,7 @@
 package com.packit.api.domain.tripItem.controller;
 
+import com.packit.api.common.response.ListResponse;
+import com.packit.api.common.response.SingleResponse;
 import com.packit.api.common.security.util.SecurityUtils;
 import com.packit.api.domain.tripItem.dto.request.TripItemCreateRequest;
 import com.packit.api.domain.tripItem.dto.request.TripItemFromTemplateRequest;
@@ -26,65 +28,68 @@ public class TripItemController {
 
     @Operation(summary = "여행 카테고리 내 아이템 생성", description = "여행 카테고리(tripCategoryId) 내에 새로운 아이템을 추가합니다.")
     @PostMapping("/trip-categories/{tripCategoryId}/trip-items")
-    public ResponseEntity<TripItemResponse> createItem(
+    public ResponseEntity<SingleResponse<TripItemResponse>> createItem(
             @PathVariable Long tripCategoryId,
             @RequestBody @Valid TripItemCreateRequest request) {
         Long userId = SecurityUtils.getCurrentUserId();
-        return ResponseEntity.ok(tripItemService.create(tripCategoryId, request, userId));
+        TripItemResponse response = tripItemService.create(tripCategoryId, request, userId);
+        return ResponseEntity.ok(new SingleResponse<>(200, "아이템 생성 완료", response));
     }
 
     @Operation(summary = "여행 카테고리 내 아이템 목록 조회", description = "tripCategoryId에 해당하는 모든 아이템을 조회합니다.")
     @GetMapping("/trip-categories/{tripCategoryId}/trip-items")
-    public ResponseEntity<List<TripItemResponse>> getItems(@PathVariable Long tripCategoryId) {
+    public ResponseEntity<ListResponse<TripItemResponse>> getItems(@PathVariable Long tripCategoryId) {
         Long userId = SecurityUtils.getCurrentUserId();
-        return ResponseEntity.ok(tripItemService.getAll(tripCategoryId, userId));
+        List<TripItemResponse> items = tripItemService.getAll(tripCategoryId, userId);
+        return ResponseEntity.ok(new ListResponse<>(200, "아이템 목록 조회 완료", items));
     }
 
     @Operation(summary = "아이템 수정", description = "아이템 이름, 수량, 메모 등의 정보를 수정합니다.")
     @PatchMapping("/trip-items/{tripItemId}")
-    public ResponseEntity<TripItemResponse> updateItem(
+    public ResponseEntity<SingleResponse<TripItemResponse>> updateItem(
             @PathVariable Long tripItemId,
             @RequestBody @Valid TripItemCreateRequest request) {
         Long userId = SecurityUtils.getCurrentUserId();
-        return ResponseEntity.ok(tripItemService.update(tripItemId, request, userId));
+        TripItemResponse updated = tripItemService.update(tripItemId, request, userId);
+        return ResponseEntity.ok(new SingleResponse<>(200, "아이템 수정 완료", updated));
     }
 
     @Operation(summary = "짐싸기 체크 상태 토글", description = "아이템의 isChecked 상태를 true/false로 전환합니다.")
     @PatchMapping("/trip-items/{tripItemId}/check")
-    public ResponseEntity<Void> toggleCheck(@PathVariable Long tripItemId) {
+    public ResponseEntity<SingleResponse<Void>> toggleCheck(@PathVariable Long tripItemId) {
         Long userId = SecurityUtils.getCurrentUserId();
         tripItemService.toggleCheck(tripItemId, userId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(new SingleResponse<>(200, "짐싸기 체크 상태 변경 완료", null));
     }
 
     @Operation(summary = "아이템 삭제", description = "해당 아이템을 삭제합니다.")
     @DeleteMapping("/trip-items/{tripItemId}")
-    public ResponseEntity<Void> deleteItem(@PathVariable Long tripItemId) {
+    public ResponseEntity<SingleResponse<Void>> deleteItem(@PathVariable Long tripItemId) {
         Long userId = SecurityUtils.getCurrentUserId();
         tripItemService.delete(tripItemId, userId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(new SingleResponse<>(200, "아이템 삭제 완료", null));
     }
 
     @Operation(summary = "템플릿 아이템 복사", description = "선택된 템플릿 아이템들을 현재 여행 카테고리 내 아이템으로 복사합니다.")
     @PostMapping("/trip-categories/{tripCategoryId}/trip-items/from-template")
-    public ResponseEntity<Void> addFromTemplate(
+    public ResponseEntity<SingleResponse<Void>> addFromTemplate(
             @PathVariable Long tripCategoryId,
             @RequestBody TripItemFromTemplateRequest request) {
         Long userId = SecurityUtils.getCurrentUserId();
         tripItemService.addItemsFromTemplate(tripCategoryId, request.templateItemIds(), userId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(new SingleResponse<>(200, "템플릿 아이템 복사 완료", null));
     }
 
     @Operation(summary = "TripItem 생성",
             description = "기본템플릿이든 사용자 입력이든, name/quantity/memo만 포함된 단순 리스트를 기반으로 TripItem 생성")
     @PostMapping("/trips/{tripId}/categories/{tripCategoryId}/items")
-    public ResponseEntity<Void> createTripItems(
+    public ResponseEntity<SingleResponse<Void>> createTripItems(
             @Parameter(description = "여행 ID") @PathVariable Long tripId,
             @Parameter(description = "여행 카테고리 ID") @PathVariable Long tripCategoryId,
             @RequestBody TripItemListCreateRequest request
     ) {
         tripItemService.createBulkItems(tripId, tripCategoryId, request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(new SingleResponse<>(200, "여러 TripItem 생성 완료", null));
     }
 
 


### PR DESCRIPTION
## 모든 Controller 응답 포맷 일관성 적용 (`SingleResponse`, `ListResponse` 적용)

###  변경 목적
- 클라이언트와의 통신에서 일관된 API 응답 구조 제공
- Swagger 문서, 에러 핸들링, 프론트 처리 일관성 향상
- 기존 `ok().build()` 또는 `noContent()` 방식 제거

###  주요 변경 사항
- 모든 `Controller`의 응답을 `SingleResponse<T>` 또는 `ListResponse<T>` 구조로 감싸서 반환하도록 통일
- 메시지(`"조회 완료"`, `"삭제 완료"` 등)를 명확히 전달하도록 개선
- `void` 반환의 경우에도 `SingleResponse<Void>` 형태로 감싸서 응답

###  적용 대상 컨트롤러
- `TripController`
- `TripCategoryController`
- `TripItemController`
- `TemplateItemController`


###  Response 포맷 예시
```json
{
  "success": true,
  "code": 200,
  "message": "카테고리 생성 완료",
  "datalist": {
    "id": 1,
    "name": "의류"
  }
}