### PR TITLE
refactor:  ListResponse datalist → data로 통일

### DIFF
--- a/api/src/main/java/com/packit/api/common/response/ListResponse.java
+++ b/api/src/main/java/com/packit/api/common/response/ListResponse.java
@@ -7,11 +7,11 @@ import java.util.List;
 
 @Getter
 public class ListResponse <T> extends  CommonResponse{
-    List<T> dataList;
+    List<T> data;
 
     @Builder
-    public ListResponse(int code, String message, List<T> dataList) {
+    public ListResponse(int code, String message, List<T> data) {
         super(true, code, message);
-        this.dataList = dataList;
+        this.data = data;
     }
 }

--- a/api/src/main/java/com/packit/api/domain/tripCategory/controller/TripCategoryController.java
+++ b/api/src/main/java/com/packit/api/domain/tripCategory/controller/TripCategoryController.java
@@ -26,7 +26,7 @@ public class TripCategoryController {
 
     private final TripCategoryService tripCategoryService;
 
-    @Operation(summary = "여행에 카테고리 추가", description = "여행(tripId)에 새로운 카테고리를 추가합니다. 기본 제공 카테고리 또는 사용자 정의 이름을 기반으로 생성할 수 있습니다.")
+    @Operation(summary = "여행에 카테고리 추가", description = "여행(tripId)에 새로운 카테고리를 추가합니다. 사용자 정의 이름을 기반으로 생성할 수 있습니다.")
     @PostMapping("/trips/{tripId}/trip-categories")
     public ResponseEntity<SingleResponse<TripCategoryResponse>> createCategory(
             @PathVariable Long tripId,


### PR DESCRIPTION
##  Refactor: `ListResponse`의 필드명 `datalist` → `data`로 통일

###  변경 사항
- 기존 `ListResponse<T>` 클래스에서 필드명 `datalist`를 `data`로 수정
- 응답 일관성을 위해 `SingleResponse<T>`와 동일한 필드명(`data`) 사용
- 프론트엔드 파싱 및 API 문서화(OpenAPI) 시 혼동 방지

###  변경 이유
- `data`는 대부분의 REST API에서 표준적으로 사용하는 필드명
- 단일 객체(`SingleResponse<T>`)와 리스트(`ListResponse<T>`) 모두 동일한 키로 응답하도록 통일
- 프론트 코드에서 `response.data` 로 통일된 파싱 가능
- Swagger 문서화 및 명세 일관성 확보

###  영향 범위
- 모든 `ListResponse` 리턴 컨트롤러 API 응답 필드 변경: `datalist` → `data`
- 기존 `response.datalist`를 사용하는 프론트엔드 코드 수정 필요

