### PR TITLE
fix: TripItem 체크 상태 변경 후 DB 반영 안 되는 이슈 해결

### DIFF
--- a/api/src/main/java/com/packit/api/domain/tripItem/service/TripItemService.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/service/TripItemService.java
@@ -11,6 +11,7 @@ import com.packit.api.domain.tripItem.dto.response.TripItemResponse;
 import com.packit.api.domain.tripItem.entity.TripItem;
 import com.packit.api.domain.tripItem.repository.TripItemRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +19,7 @@ import java.util.List;
 
 import static com.packit.api.domain.tripCategory.entity.TripCategoryStatus.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TripItemService {
@@ -46,12 +48,18 @@ public class TripItemService {
     public TripItemResponse update(Long itemId, TripItemCreateRequest request, Long userId) {
         TripItem item = getItemOwnedByUser(itemId, userId);
         item.update(request.name(), request.quantity(), request.memo());
+        tripItemRepository.save(item);
         return TripItemResponse.from(item);
     }
 
     public void toggleCheck(Long itemId, Long userId) {
         TripItem item = getItemOwnedByUser(itemId, userId);
+        log.info("Before toggle: {}", item.isChecked());
         item.toggleCheck();
+        log.info("After toggle: {}", item.isChecked());
+        tripItemRepository.save(item);
+
+
         updateCategoryStatusAfterItemChange(item.getTripCategory());
     }
 


### PR DESCRIPTION
## 🔧 작업 내용
- TripItem의 `isChecked` 상태가 변경되었음에도 불구하고, JPA의 dirty checking이 발생하지 않아 DB 반영이 되지 않는 현상 해결
- `tripItemRepository.save(item)`을 명시적으로 호출하여 변경 사항을 저장하도록 처리

##  원인
- toggleCheck() 메서드에서 필드 변경은 되었지만, 영속성 컨텍스트에서 변경 감지를 못 함

##  향후 개선 방향
- `Boolean` 타입으로 변경 및 JPA 감지 개선
- `@Transactional` 범위 검토 및 리팩토링

