### PR TITLE
feat: 마이페이지 조회 API 구현 (닉네임, 이메일 반환)

### DIFF
--- a/api/src/main/java/com/packit/api/domain/user/controller/MyPageController.java
+++ b/api/src/main/java/com/packit/api/domain/user/controller/MyPageController.java
@@ -1,0 +1,28 @@
+package com.packit.api.domain.user.controller;
+
+import com.packit.api.common.response.SingleResponse;
+import com.packit.api.common.security.util.SecurityUtils;
+import com.packit.api.domain.user.dto.response.MyPageResponse;
+import com.packit.api.domain.user.service.MyPageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user/mypage")
+@Tag(name = "MyPage", description = "마이페이지 관련 API")
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    @GetMapping
+    @Operation(summary = "내 정보 조회", description = "로그인한 회원의 이메일과 닉네임을 반환합니다.")
+    public ResponseEntity<SingleResponse<MyPageResponse>> getMyInfo() {
+        Long userId = SecurityUtils.getCurrentUserId();
+        MyPageResponse response = myPageService.getMyInfo(userId);
+        return ResponseEntity.ok(new SingleResponse<>(200, "마이페이지 조회 성공", response));
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/user/dto/PasswordCheckRequestDto.java
+++ b/api/src/main/java/com/packit/api/domain/user/dto/PasswordCheckRequestDto.java
@@ -1,6 +1,0 @@
-package com.packit.api.domain.user.dto;
-
-import lombok.Getter;
-
-public record PasswordCheckRequestDto(String password) {
-}

--- a/api/src/main/java/com/packit/api/domain/user/dto/request/NicknameUpdateRequestDto.java
+++ b/api/src/main/java/com/packit/api/domain/user/dto/request/NicknameUpdateRequestDto.java
@@ -1,3 +1,3 @@
-package com.packit.api.domain.user.dto;
+package com.packit.api.domain.user.dto.request;
 
 public record NicknameUpdateRequestDto(String nickname) {}

--- a/api/src/main/java/com/packit/api/domain/user/dto/request/PasswordCheckRequestDto.java
+++ b/api/src/main/java/com/packit/api/domain/user/dto/request/PasswordCheckRequestDto.java
@@ -1,0 +1,4 @@
+package com.packit.api.domain.user.dto.request;
+
+public record PasswordCheckRequestDto(String password) {
+}

--- a/api/src/main/java/com/packit/api/domain/user/dto/request/PasswordUpdateRequestDto.java
+++ b/api/src/main/java/com/packit/api/domain/user/dto/request/PasswordUpdateRequestDto.java
@@ -1,3 +1,3 @@
-package com.packit.api.domain.user.dto;
+package com.packit.api.domain.user.dto.request;
 
 public record PasswordUpdateRequestDto(String password) {}

--- a/api/src/main/java/com/packit/api/domain/user/dto/response/MyPageResponse.java
+++ b/api/src/main/java/com/packit/api/domain/user/dto/response/MyPageResponse.java
@@ -1,0 +1,17 @@
+package com.packit.api.domain.user.dto.response;
+
+
+import com.packit.api.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MyPageResponse(
+        @Schema(description = "회원 이메일", example = "test@example.com")
+        String email,
+
+        @Schema(description = "회원 닉네임", example = "gisu")
+        String nickname
+) {
+    public static MyPageResponse of(String email, String nickname) {
+        return new MyPageResponse(email, nickname);
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/user/entity/User.java
+++ b/api/src/main/java/com/packit/api/domain/user/entity/User.java
@@ -32,15 +32,15 @@ public class User extends BaseTimeEntity {
     private String nickname;
     @NotBlank
     @Column(nullable = false)
-    private String name; // 추가됨
+    private String name;
 
     @NotNull
     @Column(nullable = false)
-    private Integer age; // 추가됨
+    private Integer age;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Gender gender; // 추가됨
+    private Gender gender;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/api/src/main/java/com/packit/api/domain/user/service/MyPageService.java
+++ b/api/src/main/java/com/packit/api/domain/user/service/MyPageService.java
@@ -1,0 +1,20 @@
+package com.packit.api.domain.user.service;
+
+import com.packit.api.domain.user.dto.response.MyPageResponse;
+import com.packit.api.domain.user.entity.User;
+import com.packit.api.domain.user.exception.UserNotFoundException;
+import com.packit.api.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+    private final UserRepository userRepository;
+
+    public MyPageResponse getMyInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+        return MyPageResponse.of(user.getEmail(), user.getNickname());
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/user/service/UserJoinService.java
+++ b/api/src/main/java/com/packit/api/domain/user/service/UserJoinService.java
@@ -2,11 +2,10 @@ package com.packit.api.domain.user.service;
 
 
 import com.packit.api.common.exception.BadRequestException;
-import com.packit.api.domain.user.dto.NicknameUpdateRequestDto;
-import com.packit.api.domain.user.dto.PasswordCheckRequestDto;
-import com.packit.api.domain.user.dto.PasswordUpdateRequestDto;
+import com.packit.api.domain.user.dto.request.NicknameUpdateRequestDto;
+import com.packit.api.domain.user.dto.request.PasswordCheckRequestDto;
+import com.packit.api.domain.user.dto.request.PasswordUpdateRequestDto;
 import com.packit.api.domain.user.entity.User;
-import com.packit.api.domain.user.entity.UserRole;
 import com.packit.api.domain.user.exception.*;
 import com.packit.api.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## 작업 내용
- MyPage API 구현 (`/ap/mypage`)
- 현재 로그인한 사용자의 이메일과 닉네임 조회 기능 제공

## API 명세
| 기능         | Method | URL               | 설명                                 |
|--------------|--------|--------------------|----------------------------------------|
| 내 정보 조회 | GET    | `/ap/mypage`   | 현재 로그인한 사용자의 닉네임 및 이메일 반환 |

## 테스트
- 로그인된 사용자 기준으로 정보 정상 반환 확인
- 토큰 미포함 시 401 Unauthorized 응답 확인
- Swagger UI를 통한 응답 포맷 및 필드 정상 확인

## 참고 사항
- 사용자 ID는 `SecurityUtils.getCurrentUserId()`를 통해 추출