### PR TITLE
feat: 마이페이지 여행 요약 조회 API 구현

### DIFF
--- a/api/src/main/java/com/packit/api/domain/trip/dto/response/TripSummaryResponse.java
+++ b/api/src/main/java/com/packit/api/domain/trip/dto/response/TripSummaryResponse.java
@@ -1,0 +1,19 @@
+package com.packit.api.domain.trip.dto.response;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TripSummaryResponse(
+        @Schema(description = "전체 여행 수", example = "5")
+        int totalCount,
+
+        @Schema(description = "계획 중인 여행 수", example = "2")
+        int plannedCount,
+
+        @Schema(description = "완료된 여행 수", example = "3")
+        int completedCount
+) {
+    public static TripSummaryResponse of(int total, int planned, int completed) {
+        return new TripSummaryResponse(total, planned, completed);
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/trip/repository/TripRepository.java
+++ b/api/src/main/java/com/packit/api/domain/trip/repository/TripRepository.java
@@ -8,4 +8,11 @@ import java.util.List;
 
 public interface TripRepository extends JpaRepository<Trip, Long> {
     List<Trip> findAllByUserId(Long userId);
+
+    int countByUserId(Long userId);
+
+    int countByUserIdAndIsCompletedTrue(Long userId);
+
+    int countByUserIdAndIsCompletedFalse(Long userId);
 }
+

--- a/api/src/main/java/com/packit/api/domain/trip/service/TripService.java
+++ b/api/src/main/java/com/packit/api/domain/trip/service/TripService.java
@@ -5,6 +5,7 @@ import com.packit.api.domain.trip.dto.request.TripCreateRequest;
 import com.packit.api.domain.trip.dto.request.TripUpdateRequest;
 import com.packit.api.domain.trip.dto.response.TripProgressResponse;
 import com.packit.api.domain.trip.dto.response.TripResponse;
+import com.packit.api.domain.trip.dto.response.TripSummaryResponse;
 import com.packit.api.domain.trip.entity.Trip;
 import com.packit.api.domain.trip.repository.TripRepository;
 import com.packit.api.domain.tripCategory.entity.TripCategory;
@@ -87,5 +88,12 @@ public class TripService {
         double progress = total == 0 ? 0 : ((double) completed / total) * 100;
 
         return TripProgressResponse.of(total, completed, progress);
+    }
+
+    public TripSummaryResponse getTripSummaryByUser(Long userId) {
+        int total = tripRepository.countByUserId(userId);
+        int planned = tripRepository.countByUserIdAndIsCompletedFalse(userId);
+        int completed = tripRepository.countByUserIdAndIsCompletedTrue(userId);
+        return TripSummaryResponse.of(total, planned, completed);
     }
 }

--- a/api/src/main/java/com/packit/api/domain/user/controller/MyPageController.java
+++ b/api/src/main/java/com/packit/api/domain/user/controller/MyPageController.java
@@ -3,6 +3,7 @@ package com.packit.api.domain.user.controller;
 import com.packit.api.common.response.SingleResponse;
 import com.packit.api.common.security.util.SecurityUtils;
 import com.packit.api.domain.user.dto.response.MyPageResponse;
+import com.packit.api.domain.trip.dto.response.TripSummaryResponse;
 import com.packit.api.domain.user.service.MyPageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,5 +25,14 @@ public class MyPageController {
         Long userId = SecurityUtils.getCurrentUserId();
         MyPageResponse response = myPageService.getMyInfo(userId);
         return ResponseEntity.ok(new SingleResponse<>(200, "마이페이지 조회 성공", response));
+    }
+
+
+    @GetMapping("/trip-summary")
+    @Operation(summary = "여행 요약 정보 조회", description = "총 여행 횟수, 계획 중, 완료된 여행 수를 반환합니다.")
+    public ResponseEntity<SingleResponse<TripSummaryResponse>> getTripSummary() {
+        Long userId = SecurityUtils.getCurrentUserId();
+        TripSummaryResponse summary = myPageService.getTripSummary(userId);
+        return ResponseEntity.ok(new SingleResponse<>(200, "여행 요약 정보 조회 성공", summary));
     }
 }

--- a/api/src/main/java/com/packit/api/domain/user/service/MyPageService.java
+++ b/api/src/main/java/com/packit/api/domain/user/service/MyPageService.java
@@ -1,6 +1,9 @@
 package com.packit.api.domain.user.service;
 
+import com.packit.api.domain.trip.repository.TripRepository;
+import com.packit.api.domain.trip.service.TripService;
 import com.packit.api.domain.user.dto.response.MyPageResponse;
+import com.packit.api.domain.trip.dto.response.TripSummaryResponse;
 import com.packit.api.domain.user.entity.User;
 import com.packit.api.domain.user.exception.UserNotFoundException;
 import com.packit.api.domain.user.repository.UserRepository;
@@ -11,10 +14,15 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MyPageService {
     private final UserRepository userRepository;
+    private final TripService tripService;
 
     public MyPageResponse getMyInfo(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
         return MyPageResponse.of(user.getEmail(), user.getNickname());
+    }
+
+    public TripSummaryResponse getTripSummary(Long userId) {
+        return tripService.getTripSummaryByUser(userId);
     }
 }


### PR DESCRIPTION
## 작업 내용

- 마이페이지 여행 요약 정보 조회 API 구현 (`/ap/mypage/trip-summary`)
- 현재 로그인한 사용자의 전체 여행 수, 계획 중인 여행 수, 완료된 여행 수 반환

## API 명세

| 기능              | Method | URL                               | 설명                                       |
|-------------------|--------|------------------------------------|--------------------------------------------|
| 여행 요약 조회     | GET    | `/api/mypage/trip-summary`     | 총 여행 수, 계획 중, 완료된 여행 수 반환 |

## 테스트

- 사용자의 여행 수가 정상적으로 반환되는지 확인
- 각 상태(계획/완료)에 따른 카운트 정확히 계산되는지 검증

## 참고 사항
- Trip 엔티티의 isCompleted 필드 기준으로 상태 구분
- 마이페이지 통계 대시보드 구성 시 활용 가능