### PR TITLE
Feat/ai single recommend

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -53,6 +53,8 @@ dependencies {
 	//DB
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	//Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/api/src/main/java/com/packit/api/ApiApplication.java
+++ b/api/src/main/java/com/packit/api/ApiApplication.java
@@ -1,5 +1,6 @@
 package com.packit.api;
 
+import com.packit.api.common.config.AiRecommendProperties;
 import com.packit.api.common.dto.PermitAllProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -7,7 +8,10 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableConfigurationProperties(PermitAllProperties.class)
+@EnableConfigurationProperties({
+		PermitAllProperties.class,
+		AiRecommendProperties.class
+})
 @EnableJpaAuditing
 public class ApiApplication {
 

--- a/api/src/main/java/com/packit/api/common/config/AiRecommendProperties.java
+++ b/api/src/main/java/com/packit/api/common/config/AiRecommendProperties.java
@@ -1,0 +1,17 @@
+package com.packit.api.common.config;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "ai.recommendation")
+public class AiRecommendProperties {
+
+    @NotBlank
+    private String url; // 예: http://localhost:8000/ai/recommend
+}

--- a/api/src/main/java/com/packit/api/common/config/WebClientConfig.java
+++ b/api/src/main/java/com/packit/api/common/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package com.packit.api.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient(WebClient.Builder builder) {
+        return builder.build();
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/ai/client/AiRecommendApiClient.java
+++ b/api/src/main/java/com/packit/api/domain/ai/client/AiRecommendApiClient.java
@@ -1,0 +1,33 @@
+package com.packit.api.domain.ai.client;
+
+import com.packit.api.domain.ai.client.dto.AiRecommendApiRequest;
+import com.packit.api.domain.ai.client.dto.AiRecommendApiResponse;
+import com.packit.api.domain.ai.dto.response.AiRecommendedItemResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AiRecommendApiClient {
+
+    private final WebClient webClient;
+
+    @Value("${ai.recommendation.url}")
+    private String recommendUrl;
+
+    public List<AiRecommendedItemResponse> requestRecommendations(AiRecommendApiRequest request) {
+        return webClient.post()
+                .uri(recommendUrl)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToFlux(AiRecommendApiResponse.class)
+                .map(AiRecommendedItemResponse::from)  //  변환
+                .collectList()
+                .block();
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/ai/client/dto/AiRecommendApiRequest.java
+++ b/api/src/main/java/com/packit/api/domain/ai/client/dto/AiRecommendApiRequest.java
@@ -1,0 +1,41 @@
+package com.packit.api.domain.ai.client.dto;
+
+import com.packit.api.domain.trip.entity.Trip;
+import com.packit.api.domain.tripCategory.entity.TripCategory;
+import com.packit.api.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class AiRecommendApiRequest {
+    @Schema(description = "사용자 성별", example = "MALE")
+    private String gender;
+
+    @Schema(description = "사용자 나이", example = "28")
+    private Integer age;
+
+    @Schema(description = "여행 지역", example = "제주도")
+    private String region;
+
+    @Schema(description = "여행 시작일", example = "2025-07-01")
+    private String startDate;
+
+    @Schema(description = "여행 종료일", example = "2025-07-03")
+    private String endDate;
+
+    @Schema(description = "카테고리 이름", example = "의류")
+    private String categoryName;
+
+    public static AiRecommendApiRequest from(User user, Trip trip, TripCategory category) {
+        return AiRecommendApiRequest.builder()
+                .gender(user.getGender().name())  // enum → 문자열
+                .age(user.getAge())
+                .region(trip.getRegion())
+                .startDate(trip.getStartDate().toString())  // LocalDate → String
+                .endDate(trip.getEndDate().toString())
+                .categoryName(category.getName())
+                .build();
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/ai/client/dto/AiRecommendApiResponse.java
+++ b/api/src/main/java/com/packit/api/domain/ai/client/dto/AiRecommendApiResponse.java
@@ -1,0 +1,9 @@
+package com.packit.api.domain.ai.client.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AiRecommendApiResponse {
+    private String name;
+    private int quantity;
+}

--- a/api/src/main/java/com/packit/api/domain/ai/controller/AiRecommendController.java
+++ b/api/src/main/java/com/packit/api/domain/ai/controller/AiRecommendController.java
@@ -1,0 +1,37 @@
+package com.packit.api.domain.ai.controller;
+
+import com.packit.api.common.response.ListResponse;
+import com.packit.api.common.security.util.SecurityUtils;
+import com.packit.api.domain.ai.dto.request.AiRecommendRequest;
+import com.packit.api.domain.ai.dto.response.AiRecommendedItemResponse;
+import com.packit.api.domain.ai.service.AiRecommendService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/ai")
+@Tag(name = "AI 추천", description = "AI 기반 추천 아이템 API")
+public class AiRecommendController {
+
+    private final AiRecommendService aiRecommendService;
+
+    @PostMapping("/recommend")
+    @Operation(summary = "AI 추천 요청", description = "TripCategory에 기반한 추천 아이템을 반환합니다.")
+    public ResponseEntity<ListResponse<AiRecommendedItemResponse>> recommend(
+            @RequestBody @Valid AiRecommendRequest request
+    ) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        List<AiRecommendedItemResponse> items = aiRecommendService.recommendItems(userId, request);
+        return ResponseEntity.ok(new ListResponse<>(200, "AI 추천 조회 완료", items));
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/ai/dto/request/AiRecommendRequest.java
+++ b/api/src/main/java/com/packit/api/domain/ai/dto/request/AiRecommendRequest.java
@@ -1,0 +1,13 @@
+package com.packit.api.domain.ai.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "AI 추천 요청 DTO")
+public record AiRecommendRequest(
+        @Schema(description = "여행 ID", example = "1")
+        @NotNull Long tripId,
+
+        @Schema(description = "TripCategory ID", example = "5")
+        @NotNull Long tripCategoryId
+) {}

--- a/api/src/main/java/com/packit/api/domain/ai/dto/response/AiRecommendedItemResponse.java
+++ b/api/src/main/java/com/packit/api/domain/ai/dto/response/AiRecommendedItemResponse.java
@@ -1,0 +1,15 @@
+package com.packit.api.domain.ai.dto.response;
+
+import com.packit.api.domain.ai.client.dto.AiRecommendApiResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "AI 추천 아이템 응답 DTO")
+public record AiRecommendedItemResponse(
+        @Schema(description = "추천된 항목 이름") String name,
+        @Schema(description = "수량") int quantity
+) {    @Builder
+    public static AiRecommendedItemResponse from(AiRecommendApiResponse apiResponse) {
+    return new AiRecommendedItemResponse(apiResponse.getName(), apiResponse.getQuantity());
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/ai/service/AiRecommendService.java
+++ b/api/src/main/java/com/packit/api/domain/ai/service/AiRecommendService.java
@@ -1,0 +1,62 @@
+package com.packit.api.domain.ai.service;
+
+import com.packit.api.common.exception.NotFoundException;
+import com.packit.api.domain.ai.client.AiRecommendApiClient;
+import com.packit.api.domain.ai.client.dto.AiRecommendApiRequest;
+import com.packit.api.domain.ai.dto.request.AiRecommendRequest;
+import com.packit.api.domain.ai.dto.response.AiRecommendedItemResponse;
+import com.packit.api.domain.trip.entity.Trip;
+import com.packit.api.domain.trip.repository.TripRepository;
+import com.packit.api.domain.tripCategory.entity.TripCategory;
+import com.packit.api.domain.tripCategory.repository.TripCategoryRepository;
+import com.packit.api.domain.tripItem.entity.TripItem;
+import com.packit.api.domain.tripItem.repository.TripItemRepository;
+import com.packit.api.domain.user.entity.User;
+import com.packit.api.domain.user.exception.UserNotFoundException;
+import com.packit.api.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AiRecommendService {
+
+    private final AiRecommendApiClient aiRecommendApiClient; // FastAPI 연동
+    private final TripRepository tripRepository;
+    private final TripCategoryRepository tripCategoryRepository;
+    private final TripItemRepository tripItemRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public List<AiRecommendedItemResponse> recommendItems(Long userId, AiRecommendRequest request) {
+        Trip trip = tripRepository.findByIdAndUserId(request.tripId(), userId)
+                .orElseThrow(() -> new NotFoundException("여행을 찾을 수 없습니다."));
+
+        TripCategory category = tripCategoryRepository.findByIdAndTripId(request.tripCategoryId(), trip.getId())
+                .orElseThrow(() -> new NotFoundException("카테고리를 찾을 수 없습니다."));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("유저를 찾을 수 없습니다."));
+
+        // FastAPI 호출용 DTO 구성
+        AiRecommendApiRequest apiRequest = AiRecommendApiRequest.from(user, trip, category);
+
+        // FastAPI 호출
+        List<AiRecommendedItemResponse> response = aiRecommendApiClient.requestRecommendations(apiRequest);
+
+        // TripItem 저장
+        for (AiRecommendedItemResponse item : response) {
+            TripItem tripItem = TripItem.ofAiGenerated(
+                    category,
+                    item.name(),
+                    item.quantity()
+            );
+            tripItemRepository.save(tripItem);
+        }
+
+        return response;
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/trip/repository/TripRepository.java
+++ b/api/src/main/java/com/packit/api/domain/trip/repository/TripRepository.java
@@ -1,10 +1,12 @@
 package com.packit.api.domain.trip.repository;
 
 import com.packit.api.domain.trip.entity.Trip;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface TripRepository extends JpaRepository<Trip, Long> {
     List<Trip> findAllByUserId(Long userId);
@@ -14,5 +16,7 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
     int countByUserIdAndIsCompletedTrue(Long userId);
 
     int countByUserIdAndIsCompletedFalse(Long userId);
+
+    Optional<Trip> findByIdAndUserId(Long tripId, Long userId);
 }
 

--- a/api/src/main/java/com/packit/api/domain/tripItem/entity/TripItem.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/entity/TripItem.java
@@ -69,6 +69,18 @@ public class TripItem extends BaseTimeEntity {
                 .build();
     }
 
+    public static TripItem ofAiGenerated(TripCategory tripCategory, String name, int quantity) {
+        return TripItem.builder()
+                .tripCategory(tripCategory)
+                .name(name)
+                .quantity(quantity)
+                .memo(null)
+                .isChecked(false)
+                .isSaved(true)
+                .isAiGenerated(true)
+                .build();
+    }
+
     public void toggleCheck() {
         this.isChecked = !this.isChecked;
     }

--- a/api/src/main/resources/application-local.yml
+++ b/api/src/main/resources/application-local.yml
@@ -24,5 +24,9 @@ spring:
             port: 6379
             password: 1234
 
+ai:
+    recommendation:
+        url: http://localhost:8000/ai/recommend
+
 swagger:
     base-url: http://localhost:8080


### PR DESCRIPTION
##  AI 추천 기능 - TripCategory 단건 추천

###  작업 브랜치
`feat/ai-recommend-single`

---

###  주요 변경 사항
- `/api/ai/recommend` 엔드포인트 추가
- `AiRecommendRequest`: Trip ID + TripCategory ID 전달 DTO
- `AiRecommendedItemResponse`: 추천 아이템 응답 DTO
- `AiRecommendService`: TripCategory 기반 추천 → TripItem 저장
- `AiRecommendApiClient`: WebClient 기반 FastAPI 호출 로직 분리
- `AiRecommendApiRequest`: FastAPI로 보낼 사용자/여행/카테고리 정보 구성
- `AiRecommendApiResponse`: FastAPI 응답 매핑 DTO

---

###  디렉토리 구조
com.packit.api.domain.ai
├── controller
│   └── AiRecommendController.java
├── service
│   └── AiRecommendService.java
├── dto
│   ├── request
│   │   └── AiRecommendRequest.java
│   └── response
│       └── AiRecommendedItemResponse.java
├── client
│   ├── AiRecommendApiClient.java
│   └── dto
│       ├── AiRecommendApiRequest.java
│       └── AiRecommendApiResponse.java

###  향후 계획
- Trip 내 모든 TripCategory에 대해 반복 추천하는 기능 개발 예정 (`feat/ai-recommend-all`)
- 추천 내역 기록을 위한 `AiRecommendationLog` 테이블 설계 및 도입 예정