### PR TITLE
feat: Trip 전체 진행률 조회 및 체크 토글 시 진행률 반환 기능 추가

### DIFF
--- a/api/src/main/java/com/packit/api/domain/trip/controller/TripController.java
+++ b/api/src/main/java/com/packit/api/domain/trip/controller/TripController.java
@@ -5,6 +5,7 @@ import com.packit.api.common.response.SingleResponse;
 import com.packit.api.common.security.util.SecurityUtils;
 import com.packit.api.domain.trip.dto.request.TripCreateRequest;
 import com.packit.api.domain.trip.dto.request.TripUpdateRequest;
+import com.packit.api.domain.trip.dto.response.TripProgressCountResponse;
 import com.packit.api.domain.trip.dto.response.TripProgressResponse;
 import com.packit.api.domain.trip.dto.response.TripResponse;
 import com.packit.api.domain.trip.service.TripService;
@@ -88,5 +89,13 @@ public class TripController {
         Long userId = SecurityUtils.getCurrentUserId();
         TripProgressResponse progress = tripService.getTripProgress(tripId, userId);
         return ResponseEntity.ok(new SingleResponse<>(200, "짐싸기 진행률 조회 완료", progress));
+    }
+
+    @GetMapping("/{tripId}/progress-count")
+    @Operation(summary = "Trip 전체 진행률 조회", description = "해당 Trip의 전체 아이템 대비 체크된 항목 비율(%)을 반환합니다.")
+    public ResponseEntity<SingleResponse<TripProgressCountResponse>> getTripProgressCount(@PathVariable Long tripId) {
+        // 권한 체크 필요 시 TripService 내에서 수행
+        TripProgressCountResponse response = tripService.getTripProgressCount(tripId);
+        return ResponseEntity.ok(new SingleResponse<>(200, "여행 진행률 조회 성공", response));
     }
 }

--- a/api/src/main/java/com/packit/api/domain/trip/dto/response/TripProgressCountResponse.java
+++ b/api/src/main/java/com/packit/api/domain/trip/dto/response/TripProgressCountResponse.java
@@ -1,0 +1,22 @@
+package com.packit.api.domain.trip.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TripProgressCountResponse(
+        @Schema(description = "Trip ID", example = "1")
+        Long tripId,
+
+        @Schema(description = "전체 아이템 수", example = "15")
+        int totalCount,
+
+        @Schema(description = "체크된 아이템 수", example = "9")
+        int checkedCount,
+
+        @Schema(description = "진행률 (%)", example = "60")
+        int progressPercent
+) {
+    public static TripProgressCountResponse of(Long tripId, int total, int checked) {
+        int percent = total == 0 ? 0 : (int) Math.round((checked * 100.0) / total);
+        return new TripProgressCountResponse(tripId, total, checked, percent);
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/trip/service/TripService.java
+++ b/api/src/main/java/com/packit/api/domain/trip/service/TripService.java
@@ -3,6 +3,7 @@ package com.packit.api.domain.trip.service;
 import com.packit.api.common.security.util.SecurityUtils;
 import com.packit.api.domain.trip.dto.request.TripCreateRequest;
 import com.packit.api.domain.trip.dto.request.TripUpdateRequest;
+import com.packit.api.domain.trip.dto.response.TripProgressCountResponse;
 import com.packit.api.domain.trip.dto.response.TripProgressResponse;
 import com.packit.api.domain.trip.dto.response.TripResponse;
 import com.packit.api.domain.trip.dto.response.TripSummaryResponse;
@@ -95,5 +96,14 @@ public class TripService {
         int planned = tripRepository.countByUserIdAndIsCompletedFalse(userId);
         int completed = tripRepository.countByUserIdAndIsCompletedTrue(userId);
         return TripSummaryResponse.of(total, planned, completed);
+    }
+
+    public TripProgressCountResponse getTripProgress(Long tripId) {
+        List<TripItem> items = tripItemRepository.findAllByTripId(tripId);
+
+        int total = items.size();
+        int checked = (int) items.stream().filter(TripItem::isChecked).count();
+
+        return TripProgressCountResponse.of(tripId, total, checked);
     }
 }

--- a/api/src/main/java/com/packit/api/domain/trip/service/TripService.java
+++ b/api/src/main/java/com/packit/api/domain/trip/service/TripService.java
@@ -98,7 +98,7 @@ public class TripService {
         return TripSummaryResponse.of(total, planned, completed);
     }
 
-    public TripProgressCountResponse getTripProgress(Long tripId) {
+    public TripProgressCountResponse getTripProgressCount(Long tripId) {
         List<TripItem> items = tripItemRepository.findAllByTripId(tripId);
 
         int total = items.size();

--- a/api/src/main/java/com/packit/api/domain/tripItem/controller/TripItemController.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/controller/TripItemController.java
@@ -3,6 +3,7 @@ package com.packit.api.domain.tripItem.controller;
 import com.packit.api.common.response.ListResponse;
 import com.packit.api.common.response.SingleResponse;
 import com.packit.api.common.security.util.SecurityUtils;
+import com.packit.api.domain.trip.dto.response.TripProgressCountResponse;
 import com.packit.api.domain.tripItem.dto.request.TripItemCreateRequest;
 import com.packit.api.domain.tripItem.dto.request.TripItemFromTemplateRequest;
 import com.packit.api.domain.tripItem.dto.request.TripItemListCreateRequest;
@@ -56,10 +57,10 @@ public class TripItemController {
 
     @Operation(summary = "짐싸기 체크 상태 토글", description = "아이템의 isChecked 상태를 true/false로 전환합니다.")
     @PatchMapping("/trip-items/{tripItemId}/check")
-    public ResponseEntity<SingleResponse<Void>> toggleCheck(@PathVariable Long tripItemId) {
+    public ResponseEntity<SingleResponse<TripProgressCountResponse>> toggleCheck(@PathVariable Long tripItemId) {
         Long userId = SecurityUtils.getCurrentUserId();
-        tripItemService.toggleCheck(tripItemId, userId);
-        return ResponseEntity.ok(new SingleResponse<>(200, "짐싸기 체크 상태 변경 완료", null));
+        TripProgressCountResponse response = tripItemService.toggleCheck(tripItemId, userId);
+        return ResponseEntity.ok(new SingleResponse<>(200, "짐싸기 체크 상태 변경 완료", response));
     }
 
     @Operation(summary = "아이템 삭제", description = "해당 아이템을 삭제합니다.")

--- a/api/src/main/java/com/packit/api/domain/tripItem/repository/TripItemRepository.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/repository/TripItemRepository.java
@@ -3,6 +3,7 @@ package com.packit.api.domain.tripItem.repository;
 import com.packit.api.domain.tripCategory.entity.TripCategory;
 import com.packit.api.domain.tripItem.entity.TripItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -10,4 +11,10 @@ public interface TripItemRepository extends JpaRepository<TripItem, Long> {
     List<TripItem> findAllByTripCategoryId(Long tripCategoryId);
 
     List<TripItem> findAllByTripCategory(TripCategory category);
+
+    @Query("SELECT ti FROM TripItem ti " +
+            "JOIN ti.tripCategory tc " +
+            "JOIN tc.trip t " +
+            "WHERE t.id = :tripId")
+    List<TripItem> findAllByTripId(Long tripId);
 }

--- a/api/src/main/java/com/packit/api/domain/tripItem/service/TripItemService.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/service/TripItemService.java
@@ -68,7 +68,7 @@ public class TripItemService {
 
 
         updateCategoryStatusAfterItemChange(item.getTripCategory());
-        return tripService.getTripProgress(trip.getId());
+        return tripService.getTripProgressCount(trip.getId());
     }
 
     public void delete(Long itemId, Long userId) {

--- a/api/src/main/java/com/packit/api/domain/tripItem/service/TripItemService.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/service/TripItemService.java
@@ -2,6 +2,9 @@ package com.packit.api.domain.tripItem.service;
 
 import com.packit.api.domain.templateItem.entity.TemplateItem;
 import com.packit.api.domain.templateItem.repository.TemplateItemRepository;
+import com.packit.api.domain.trip.dto.response.TripProgressCountResponse;
+import com.packit.api.domain.trip.entity.Trip;
+import com.packit.api.domain.trip.service.TripService;
 import com.packit.api.domain.tripCategory.entity.TripCategory;
 import com.packit.api.domain.tripCategory.repository.TripCategoryRepository;
 import com.packit.api.domain.tripCategory.service.TripCategoryService;
@@ -28,6 +31,7 @@ public class TripItemService {
     private final TripCategoryRepository tripCategoryRepository;
     private final TemplateItemRepository templateItemRepository;
     private final TripCategoryService tripCategoryService;
+    private final TripService tripService;
 
     public TripItemResponse create(Long tripCategoryId, TripItemCreateRequest request, Long userId) {
         TripCategory category = getCategoryOwnedByUser(tripCategoryId, userId);
@@ -52,15 +56,19 @@ public class TripItemService {
         return TripItemResponse.from(item);
     }
 
-    public void toggleCheck(Long itemId, Long userId) {
+    public TripProgressCountResponse toggleCheck(Long itemId, Long userId) {
         TripItem item = getItemOwnedByUser(itemId, userId);
+        Trip trip = getTripOwnerByUser(item.getTripCategory().getTrip(), userId);
+
         log.info("Before toggle: {}", item.isChecked());
         item.toggleCheck();
         log.info("After toggle: {}", item.isChecked());
         tripItemRepository.save(item);
 
 
+
         updateCategoryStatusAfterItemChange(item.getTripCategory());
+        return tripService.getTripProgress(trip.getId());
     }
 
     public void delete(Long itemId, Long userId) {
@@ -87,6 +95,12 @@ public class TripItemService {
         if (!category.getTrip().getUser().getId().equals(userId)) {
             throw new SecurityException("본인의 여행 항목만 관리할 수 있습니다.");
         }
+    }
+    private Trip getTripOwnerByUser(Trip trip, Long userId) {
+        if (!trip.getUser().getId().equals(userId)) {
+            throw new SecurityException("본인의 여행 항목만 관리할 수 있습니다.");
+        }
+        return trip;
     }
 
     public void addItemsFromTemplate(Long tripCategoryId, List<Long> templateItemIds, Long userId) {
@@ -143,4 +157,5 @@ public class TripItemService {
 
         tripItemRepository.saveAll(tripItems);
     }
+
 }


### PR DESCRIPTION
## 작업 내용

- Trip 전체 진행률 계산 및 반환 기능 추가
  - TripItem 기준 전체 수, 체크된 수, 진행률(%) 계산
  - 퍼센트는 소수점 없이 정수형으로 반올림 처리
- Trip 진행률 단독 조회 API 구현 (`GET /api/v1/trips/{tripId}/progress`)
  - TripService에서 권한 검증 및 진행률 계산 수행
  - TripRepository에 findByIdWithUser (`JOIN FETCH`) 메서드 구현
- TripItem 체크 상태 토글 시 Trip 전체 진행률 반환 기능 추가 (`PATCH /api/v1/trip-items/{tripItemId}/check`)
  - TripItemService에서 토글 처리 후 TripService에 진행률 위임
  - TripItemRepository에 Trip 기준 전체 아이템 조회 쿼리 추가
- 공통 응답 DTO: `TripProgressCountResponse` 사용 (tripId, totalCount, checkedCount, progressPercent)

## API 명세

| 기능                         | Method | URL                                      | 설명                                                 |
|------------------------------|--------|-------------------------------------------|------------------------------------------------------|
| Trip 진행률 단독 조회        | GET    | `/api/v1/trips/{tripId}/progress`         | Trip 전체 기준 진행률(%) 반환                        |
| TripItem 체크 + 진행률 반환 | PATCH  | `/api/v1/trip-items/{tripItemId}/check`   | TripItem 체크 토글 후, Trip 기준 진행률(%) 반환      |

## 테스트

- 특정 Trip ID로 조회 시, 전체/체크된 아이템 수 기반으로 정확한 진행률 계산 확인
- 체크 토글 후 응답값으로 Trip 진행률이 정확히 계산되는지 확인
- 항목 수 0개일 경우 진행률은 0% 반환
- 사용자가 소유하지 않은 Trip/Item 접근 시 403 Forbidden 응답 확인
- Swagger UI에서 요청/응답 필드 및 예시 확인

## 참고 사항

- TripService에 진행률 계산 책임 집중 (도메인 응집도 향상)
- 진행률 계산 공식: `(checked / total) * 100`, 반올림 처리
- 추후 100% 시 Trip의 `isCompleted = true` 자동 업데이트 등 확장 가능