### PR TITLE
feat: TripItem 다중 삭제 API 구현

### DIFF
--- a/api/src/main/java/com/packit/api/domain/tripItem/controller/TripItemController.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/controller/TripItemController.java
@@ -5,6 +5,7 @@ import com.packit.api.common.response.SingleResponse;
 import com.packit.api.common.security.util.SecurityUtils;
 import com.packit.api.domain.trip.dto.response.TripProgressCountResponse;
 import com.packit.api.domain.tripItem.dto.request.TripItemCreateRequest;
+import com.packit.api.domain.tripItem.dto.request.TripItemDeleteRequest;
 import com.packit.api.domain.tripItem.dto.request.TripItemFromTemplateRequest;
 import com.packit.api.domain.tripItem.dto.request.TripItemListCreateRequest;
 import com.packit.api.domain.tripItem.dto.response.TripItemResponse;
@@ -68,6 +69,16 @@ public class TripItemController {
     public ResponseEntity<SingleResponse<Void>> deleteItem(@PathVariable Long tripItemId) {
         Long userId = SecurityUtils.getCurrentUserId();
         tripItemService.delete(tripItemId, userId);
+        return ResponseEntity.ok(new SingleResponse<>(200, "아이템 삭제 완료", null));
+    }
+
+    @Operation(summary = "아이템 여러 개 삭제", description = "여러 TripItem을 한 번에 삭제합니다.")
+    @DeleteMapping("/trip-items")
+    public ResponseEntity<SingleResponse<Void>> deleteItems(
+            @RequestBody TripItemDeleteRequest request
+    ) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        tripItemService.deleteItems(request.getTripItemIds(), userId);
         return ResponseEntity.ok(new SingleResponse<>(200, "아이템 삭제 완료", null));
     }
 

--- a/api/src/main/java/com/packit/api/domain/tripItem/dto/request/TripItemDeleteRequest.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/dto/request/TripItemDeleteRequest.java
@@ -1,0 +1,25 @@
+package com.packit.api.domain.tripItem.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class TripItemDeleteRequest {
+
+    @Schema(description = "삭제할 아이템 ID 리스트", example = "[1, 2, 3]")
+    @NotEmpty(message = "삭제할 아이템 ID 리스트는 비어있을 수 없습니다.")
+    private List<Long> tripItemIds;
+
+    private TripItemDeleteRequest(List<Long> tripItemIds) {
+        this.tripItemIds = tripItemIds;
+    }
+
+    public static TripItemDeleteRequest of(List<Long> ids) {
+        return new TripItemDeleteRequest(ids);
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/tripItem/service/TripItemService.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/service/TripItemService.java
@@ -77,6 +77,15 @@ public class TripItemService {
         updateCategoryStatusAfterItemChange(item.getTripCategory());
     }
 
+    @Transactional
+    public void deleteItems(List<Long> itemIds, Long userId) {
+        for (Long itemId : itemIds) {
+            TripItem item = getItemOwnedByUser(itemId, userId);
+            tripItemRepository.delete(item);
+            updateCategoryStatusAfterItemChange(item.getTripCategory());
+        }
+    }
+
     private TripItem getItemOwnedByUser(Long itemId, Long userId) {
         TripItem item = tripItemRepository.findById(itemId)
                 .orElseThrow(() -> new IllegalArgumentException("아이템을 찾을 수 없습니다."));


### PR DESCRIPTION
## 작업 내용

- TripItem 다중 삭제 API 구현 (`DELETE /api/v1/trip-items`)
- TripItemDeleteRequest DTO 정의 (tripItemIds: List<Long>)
- TripItemService에 deleteAll(List<Long>, Long userId) 메서드 추가

## API 명세

| 기능             | Method | URL                          | 설명                                  |
|------------------|--------|-------------------------------|---------------------------------------|
| 아이템 다중 삭제 | DELETE | `/api/trip-items`         | 선택한 TripItem 여러 개 삭제         |

