### PR TITLE
feat: 가장 가까운 미완료 여행 조회 API 구현 ( 진행률 포함 )

### DIFF
--- a/api/src/main/java/com/packit/api/domain/trip/controller/TripController.java
+++ b/api/src/main/java/com/packit/api/domain/trip/controller/TripController.java
@@ -5,6 +5,7 @@ import com.packit.api.common.response.SingleResponse;
 import com.packit.api.common.security.util.SecurityUtils;
 import com.packit.api.domain.trip.dto.request.TripCreateRequest;
 import com.packit.api.domain.trip.dto.request.TripUpdateRequest;
+import com.packit.api.domain.trip.dto.response.TripNearestResponse;
 import com.packit.api.domain.trip.dto.response.TripProgressCountResponse;
 import com.packit.api.domain.trip.dto.response.TripProgressResponse;
 import com.packit.api.domain.trip.dto.response.TripResponse;
@@ -97,5 +98,13 @@ public class TripController {
         // 권한 체크 필요 시 TripService 내에서 수행
         TripProgressCountResponse response = tripService.getTripProgressCount(tripId);
         return ResponseEntity.ok(new SingleResponse<>(200, "여행 진행률 조회 성공", response));
+    }
+
+    @Operation(summary = "가장 가까운 완료된 여행 조회", description = "오늘 이후 출발하는 완료된 여행 중 가장 빠른 여행을 조회합니다.")
+    @GetMapping("/trips/nearest-completed")
+    public ResponseEntity<SingleResponse<TripNearestResponse>> getNearestCompletedTrip() {
+        Long userId = SecurityUtils.getCurrentUserId();
+        TripNearestResponse response = tripService.getNearestCompletedTrip(userId);
+        return ResponseEntity.ok(new SingleResponse<>(200, "조회 성공", response));
     }
 }

--- a/api/src/main/java/com/packit/api/domain/trip/dto/response/TripNearestResponse.java
+++ b/api/src/main/java/com/packit/api/domain/trip/dto/response/TripNearestResponse.java
@@ -1,0 +1,33 @@
+package com.packit.api.domain.trip.dto.response;
+
+import com.packit.api.domain.trip.entity.Trip;
+import com.packit.api.domain.trip.entity.TripType;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record TripNearestResponse(
+        Long tripId,
+        String title,
+        String region,
+        String description,
+        LocalDate startDate,
+        LocalDate endDate,
+        TripType tripType,
+        int progressRate
+) {
+    public static TripNearestResponse from(Trip trip, int totalCount, int checkedCount) {
+        int progressRate = (totalCount == 0) ? 0 : (int) ((checkedCount * 100.0) / totalCount);
+        return TripNearestResponse.builder()
+                .tripId(trip.getId())
+                .title(trip.getTitle())
+                .region(trip.getRegion())
+                .description(trip.getDescription())
+                .startDate(trip.getStartDate())
+                .endDate(trip.getEndDate())
+                .tripType(trip.getTripType())
+                .progressRate(progressRate)
+                .build();
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/trip/repository/TripRepository.java
+++ b/api/src/main/java/com/packit/api/domain/trip/repository/TripRepository.java
@@ -2,9 +2,13 @@ package com.packit.api.domain.trip.repository;
 
 import com.packit.api.domain.trip.entity.Trip;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface TripRepository extends JpaRepository<Trip, Long> {
     List<Trip> findAllByUserId(Long userId);
@@ -14,5 +18,15 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
     int countByUserIdAndIsCompletedTrue(Long userId);
 
     int countByUserIdAndIsCompletedFalse(Long userId);
+
+    @Query("""
+    SELECT t FROM Trip t
+    WHERE t.user.id = :userId
+      AND t.isCompleted = false
+      AND t.startDate >= :today
+    ORDER BY t.startDate ASC
+    LIMIT 1
+""")
+    Optional<Trip> findNearestCompletedTripAfterToday(@Param("userId") Long userId, @Param("today") LocalDate today);
 }
 

--- a/api/src/main/java/com/packit/api/domain/trip/service/TripService.java
+++ b/api/src/main/java/com/packit/api/domain/trip/service/TripService.java
@@ -3,10 +3,7 @@ package com.packit.api.domain.trip.service;
 import com.packit.api.common.security.util.SecurityUtils;
 import com.packit.api.domain.trip.dto.request.TripCreateRequest;
 import com.packit.api.domain.trip.dto.request.TripUpdateRequest;
-import com.packit.api.domain.trip.dto.response.TripProgressCountResponse;
-import com.packit.api.domain.trip.dto.response.TripProgressResponse;
-import com.packit.api.domain.trip.dto.response.TripResponse;
-import com.packit.api.domain.trip.dto.response.TripSummaryResponse;
+import com.packit.api.domain.trip.dto.response.*;
 import com.packit.api.domain.trip.entity.Trip;
 import com.packit.api.domain.trip.repository.TripRepository;
 import com.packit.api.domain.tripCategory.entity.TripCategory;
@@ -19,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static com.packit.api.domain.tripCategory.entity.TripCategoryStatus.COMPLETED;
@@ -105,5 +103,17 @@ public class TripService {
         int checked = (int) items.stream().filter(TripItem::isChecked).count();
 
         return TripProgressCountResponse.of(tripId, total, checked);
+    }
+
+    public TripNearestResponse getNearestCompletedTrip(Long userId) {
+        LocalDate today = LocalDate.now();
+        Trip trip = tripRepository.findNearestCompletedTripAfterToday(userId, today)
+                .orElseThrow(() -> new RuntimeException("TRIP_NOT_FOUND"));
+
+        List<TripItem> items = tripItemRepository.findAllByTripId(trip.getId());
+        int total = items.size();
+        int checked = (int) items.stream().filter(TripItem::isChecked).count();
+
+        return TripNearestResponse.from(trip, total, checked);
     }
 }


### PR DESCRIPTION
## 작업 내용

- 오늘 날짜 기준 가장 가까운 **짐싸기 미완료 여행** 조회 API 구현 (`GET /api/v1/trips/nearest`)
- Trip 엔티티에서 `isCompleted = false` 조건과 `startDate >= today` 기준으로 가장 가까운 Trip 1건 조회
- Trip 진행률 (전체 아이템 수, 체크된 수, 퍼센트) 계산하여 응답에 포함
- `TripNearestResponse` DTO에 `totalCount`, `checkedCount`, `progressPercent` 필드 추가
- `TripRepository`에 `findNearestNotCompletedTripAfterToday()` 메서드(JPQL) 구현
- 인증된 사용자 기준으로 본인 여행만 조회 가능하도록 처리

---

## API 명세

| 기능                     | Method | URL                          | 설명                                               |
|--------------------------|--------|-------------------------------|----------------------------------------------------|
| 가장 가까운 여행 조회    | GET    | `/api/v1/trips/nearest`      | 오늘 이후 시작하는 짐싸기 미완료 여행 1건 + 진행률 포함 반환 |

---

## 응답 필드 (TripNearestResponse)

| 필드명         | 타입       | 설명                         |
|----------------|------------|------------------------------|
| tripId         | Long       | 여행 ID                      |
| title          | String     | 여행 제목                    |
| region         | String     | 여행 지역                    |
| description    | String     | 여행 설명                    |
| startDate      | LocalDate  | 시작일                       |
| endDate        | LocalDate  | 종료일                       |
| tripType       | Enum       | 여행 유형                    |
| progressPercent| int        | 진행률 (%)                   |

---

## 테스트

- 오늘 이후 시작하는 여행 중 가장 가까운 `isCompleted = false` 여행이 정확히 조회되는지 확인
- 본인 여행이 아닌 경우 403 Forbidden 처리 확인
- 진행률 계산 시 전체 0개인 경우 퍼센트는 0으로 반환되는지 확인
- Swagger에서 요청/응답 필드 정상 확인

---

## 참고 사항

- 추후 여행 전체 완료 조건(진행률 100%) 자동 업데이트 연계 가능
- 진행률은 소수점 없이 정수형으로 반환되며, `Math.round()` 사용