### PR TITLE
Feat/ai recommend

### DIFF
--- a/ai/app/api/v1/recommend.py
+++ b/ai/app/api/v1/recommend.py
@@ -51,6 +51,15 @@ MULTI_CATEGORY_LIST = [
     "의류", "전자기기", "세면도구", "약품", "기타"
 ]
 
+class RecommendRequest(BaseModel):
+    gender: str
+    age: int
+    title: str
+    region: str
+    startDate: str
+    endDate: str
+    description: str
+    tripType: List[str]
 class CategoryRecommendResponse(BaseModel):
     category: str
     items: List[TripItemRecommendResponse]

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -53,6 +53,8 @@ dependencies {
 	//DB
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	//Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/api/src/main/java/com/packit/api/ApiApplication.java
+++ b/api/src/main/java/com/packit/api/ApiApplication.java
@@ -1,5 +1,6 @@
 package com.packit.api;
 
+import com.packit.api.common.config.AiRecommendProperties;
 import com.packit.api.common.dto.PermitAllProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -7,7 +8,10 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableConfigurationProperties(PermitAllProperties.class)
+@EnableConfigurationProperties({
+		PermitAllProperties.class,
+		AiRecommendProperties.class
+})
 @EnableJpaAuditing
 public class ApiApplication {
 

--- a/api/src/main/java/com/packit/api/common/config/AiRecommendProperties.java
+++ b/api/src/main/java/com/packit/api/common/config/AiRecommendProperties.java
@@ -1,0 +1,17 @@
+package com.packit.api.common.config;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "ai.recommendation")
+public class AiRecommendProperties {
+
+    @NotBlank
+    private String url; // 예: http://localhost:8000/ai/recommend
+}

--- a/api/src/main/java/com/packit/api/common/config/WebClientConfig.java
+++ b/api/src/main/java/com/packit/api/common/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package com.packit.api.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient(WebClient.Builder builder) {
+        return builder.build();
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/ai/client/AiRecommendApiClient.java
+++ b/api/src/main/java/com/packit/api/domain/ai/client/AiRecommendApiClient.java
@@ -20,13 +20,12 @@ public class AiRecommendApiClient {
     @Value("${ai.recommendation.url}")
     private String recommendUrl;
 
-    public List<AiRecommendedItemResponse> requestRecommendations(AiRecommendApiRequest request) {
+    public List<AiRecommendApiResponse> requestRecommendations(AiRecommendApiRequest request) {
         return webClient.post()
                 .uri(recommendUrl)
                 .bodyValue(request)
                 .retrieve()
-                .bodyToFlux(AiRecommendApiResponse.class)
-                .map(AiRecommendedItemResponse::from)  //  변환
+                .bodyToFlux(AiRecommendApiResponse.class)//  변환
                 .collectList()
                 .block();
     }

--- a/api/src/main/java/com/packit/api/domain/ai/client/AiRecommendApiClient.java
+++ b/api/src/main/java/com/packit/api/domain/ai/client/AiRecommendApiClient.java
@@ -1,0 +1,33 @@
+package com.packit.api.domain.ai.client;
+
+import com.packit.api.domain.ai.client.dto.AiRecommendApiRequest;
+import com.packit.api.domain.ai.client.dto.AiRecommendApiResponse;
+import com.packit.api.domain.ai.dto.response.AiRecommendedItemResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AiRecommendApiClient {
+
+    private final WebClient webClient;
+
+    @Value("${ai.recommendation.url}")
+    private String recommendUrl;
+
+    public List<AiRecommendedItemResponse> requestRecommendations(AiRecommendApiRequest request) {
+        return webClient.post()
+                .uri(recommendUrl)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToFlux(AiRecommendApiResponse.class)
+                .map(AiRecommendedItemResponse::from)  //  변환
+                .collectList()
+                .block();
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/ai/client/dto/AiRecommendApiRequest.java
+++ b/api/src/main/java/com/packit/api/domain/ai/client/dto/AiRecommendApiRequest.java
@@ -1,0 +1,41 @@
+package com.packit.api.domain.ai.client.dto;
+
+import com.packit.api.domain.trip.entity.Trip;
+import com.packit.api.domain.tripCategory.entity.TripCategory;
+import com.packit.api.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class AiRecommendApiRequest {
+    @Schema(description = "사용자 성별", example = "MALE")
+    private String gender;
+
+    @Schema(description = "사용자 나이", example = "28")
+    private Integer age;
+
+    @Schema(description = "여행 지역", example = "제주도")
+    private String region;
+
+    @Schema(description = "여행 시작일", example = "2025-07-01")
+    private String startDate;
+
+    @Schema(description = "여행 종료일", example = "2025-07-03")
+    private String endDate;
+
+    @Schema(description = "카테고리 이름", example = "의류")
+    private String categoryName;
+
+    public static AiRecommendApiRequest from(User user, Trip trip, TripCategory category) {
+        return AiRecommendApiRequest.builder()
+                .gender(user.getGender().name())  // enum → 문자열
+                .age(user.getAge())
+                .region(trip.getRegion())
+                .startDate(trip.getStartDate().toString())  // LocalDate → String
+                .endDate(trip.getEndDate().toString())
+                .categoryName(category.getName())
+                .build();
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/ai/client/dto/AiRecommendApiRequest.java
+++ b/api/src/main/java/com/packit/api/domain/ai/client/dto/AiRecommendApiRequest.java
@@ -1,20 +1,31 @@
 package com.packit.api.domain.ai.client.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.packit.api.domain.trip.entity.Trip;
+import com.packit.api.domain.trip.entity.TripType;
 import com.packit.api.domain.tripCategory.entity.TripCategory;
 import com.packit.api.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
 
 @Builder
 @Getter
 public class AiRecommendApiRequest {
+
     @Schema(description = "사용자 성별", example = "MALE")
     private String gender;
 
     @Schema(description = "사용자 나이", example = "28")
     private Integer age;
+
+    @Schema(description = "여행 제목", example = "제주도")
+    private String title;
 
     @Schema(description = "여행 지역", example = "제주도")
     private String region;
@@ -25,17 +36,25 @@ public class AiRecommendApiRequest {
     @Schema(description = "여행 종료일", example = "2025-07-03")
     private String endDate;
 
-    @Schema(description = "카테고리 이름", example = "의류")
-    private String categoryName;
+    @Schema(description = "여행 설명", example = "보원이랑 예나랑 제욱이랑 햄버거파티하러 미국간다")
+    private String description;
 
-    public static AiRecommendApiRequest from(User user, Trip trip, TripCategory category) {
+    @Schema(description = "여행 유형 태그 목록", example = "[\"여름\", \"해외\", \"아이 동반\"]")
+    @JsonProperty("tripType") // ✅ FastAPI 요구 형식에 맞춤
+    private List<String> tripTypes;
+
+    public static AiRecommendApiRequest from(User user, Trip trip) {
         return AiRecommendApiRequest.builder()
-                .gender(user.getGender().name())  // enum → 문자열
+                .gender(user.getGender().name())
                 .age(user.getAge())
+                .title(trip.getTitle())
                 .region(trip.getRegion())
-                .startDate(trip.getStartDate().toString())  // LocalDate → String
+                .startDate(trip.getStartDate().toString())
                 .endDate(trip.getEndDate().toString())
-                .categoryName(category.getName())
+                .description(trip.getDescription())
+                .tripTypes(trip.getTripTypes().stream()
+                        .map(TripType::getDisplayName)
+                        .toList())
                 .build();
     }
 }

--- a/api/src/main/java/com/packit/api/domain/ai/client/dto/AiRecommendApiResponse.java
+++ b/api/src/main/java/com/packit/api/domain/ai/client/dto/AiRecommendApiResponse.java
@@ -1,9 +1,25 @@
 package com.packit.api.domain.ai.client.dto;
-
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class AiRecommendApiResponse {
-    private String name;
-    private int quantity;
+
+    @Schema(description = "카테고리명", example = "의류")
+    private String category;
+
+    @Schema(description = "추천 아이템 목록")
+    private List<AiRecommendItem> items;
+
+    @Getter
+    public static class AiRecommendItem {
+
+        @Schema(description = "아이템 이름", example = "속옷")
+        private String name;
+
+        @Schema(description = "아이템 수량", example = "3")
+        private int quantity;
+    }
 }

--- a/api/src/main/java/com/packit/api/domain/ai/client/dto/AiRecommendApiResponse.java
+++ b/api/src/main/java/com/packit/api/domain/ai/client/dto/AiRecommendApiResponse.java
@@ -1,0 +1,9 @@
+package com.packit.api.domain.ai.client.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AiRecommendApiResponse {
+    private String name;
+    private int quantity;
+}

--- a/api/src/main/java/com/packit/api/domain/ai/controller/AiRecommendController.java
+++ b/api/src/main/java/com/packit/api/domain/ai/controller/AiRecommendController.java
@@ -3,6 +3,7 @@ package com.packit.api.domain.ai.controller;
 import com.packit.api.common.response.ListResponse;
 import com.packit.api.common.security.util.SecurityUtils;
 import com.packit.api.domain.ai.dto.request.AiRecommendRequest;
+import com.packit.api.domain.ai.dto.response.AiRecommendedCategoryResponse;
 import com.packit.api.domain.ai.dto.response.AiRecommendedItemResponse;
 import com.packit.api.domain.ai.service.AiRecommendService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,11 +28,11 @@ public class AiRecommendController {
 
     @PostMapping("/recommend")
     @Operation(summary = "AI 추천 요청", description = "TripCategory에 기반한 추천 아이템을 반환합니다.")
-    public ResponseEntity<ListResponse<AiRecommendedItemResponse>> recommend(
+    public ResponseEntity<ListResponse<AiRecommendedCategoryResponse>> recommend(
             @RequestBody @Valid AiRecommendRequest request
     ) {
         Long userId = SecurityUtils.getCurrentUserId();
-        List<AiRecommendedItemResponse> items = aiRecommendService.recommendItems(userId, request);
+        List<AiRecommendedCategoryResponse> items = aiRecommendService.recommendItems(userId, request);
         return ResponseEntity.ok(new ListResponse<>(200, "AI 추천 조회 완료", items));
     }
 }

--- a/api/src/main/java/com/packit/api/domain/ai/controller/AiRecommendController.java
+++ b/api/src/main/java/com/packit/api/domain/ai/controller/AiRecommendController.java
@@ -11,10 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -33,6 +30,15 @@ public class AiRecommendController {
     ) {
         Long userId = SecurityUtils.getCurrentUserId();
         List<AiRecommendedCategoryResponse> items = aiRecommendService.recommendItems(userId, request);
-        return ResponseEntity.ok(new ListResponse<>(200, "AI 추천 조회 완료", items));
+        return ResponseEntity.ok(new ListResponse<>(200, "AI 추천 생성 완료", items));
+    }
+
+    @GetMapping("/recommend/items")
+    @Operation(summary = "카테고리별 AI 추천 아이템 조회", description = "TripCategory ID를 기준으로 AI 추천 아이템을 조회합니다.")
+    public ResponseEntity<ListResponse<AiRecommendedItemResponse>> getRecommendedItemsByCategory(
+            @RequestParam Long tripCategoryId
+    ) {
+        List<AiRecommendedItemResponse> response = aiRecommendService.getRecommendationsByTripCategory(tripCategoryId);
+        return ResponseEntity.ok(new ListResponse<>(200, "AI 추천 리스트 조회",response));
     }
 }

--- a/api/src/main/java/com/packit/api/domain/ai/controller/AiRecommendController.java
+++ b/api/src/main/java/com/packit/api/domain/ai/controller/AiRecommendController.java
@@ -1,0 +1,37 @@
+package com.packit.api.domain.ai.controller;
+
+import com.packit.api.common.response.ListResponse;
+import com.packit.api.common.security.util.SecurityUtils;
+import com.packit.api.domain.ai.dto.request.AiRecommendRequest;
+import com.packit.api.domain.ai.dto.response.AiRecommendedItemResponse;
+import com.packit.api.domain.ai.service.AiRecommendService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/ai")
+@Tag(name = "AI 추천", description = "AI 기반 추천 아이템 API")
+public class AiRecommendController {
+
+    private final AiRecommendService aiRecommendService;
+
+    @PostMapping("/recommend")
+    @Operation(summary = "AI 추천 요청", description = "TripCategory에 기반한 추천 아이템을 반환합니다.")
+    public ResponseEntity<ListResponse<AiRecommendedItemResponse>> recommend(
+            @RequestBody @Valid AiRecommendRequest request
+    ) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        List<AiRecommendedItemResponse> items = aiRecommendService.recommendItems(userId, request);
+        return ResponseEntity.ok(new ListResponse<>(200, "AI 추천 조회 완료", items));
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/ai/dto/request/AiRecommendRequest.java
+++ b/api/src/main/java/com/packit/api/domain/ai/dto/request/AiRecommendRequest.java
@@ -1,0 +1,13 @@
+package com.packit.api.domain.ai.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "AI 추천 요청 DTO")
+public record AiRecommendRequest(
+        @Schema(description = "여행 ID", example = "1")
+        @NotNull Long tripId,
+
+        @Schema(description = "TripCategory ID", example = "5")
+        @NotNull Long tripCategoryId
+) {}

--- a/api/src/main/java/com/packit/api/domain/ai/dto/request/AiRecommendRequest.java
+++ b/api/src/main/java/com/packit/api/domain/ai/dto/request/AiRecommendRequest.java
@@ -6,8 +6,5 @@ import jakarta.validation.constraints.NotNull;
 @Schema(description = "AI 추천 요청 DTO")
 public record AiRecommendRequest(
         @Schema(description = "여행 ID", example = "1")
-        @NotNull Long tripId,
-
-        @Schema(description = "TripCategory ID", example = "5")
-        @NotNull Long tripCategoryId
+        @NotNull Long tripId
 ) {}

--- a/api/src/main/java/com/packit/api/domain/ai/dto/response/AiRecommendedCategoryResponse.java
+++ b/api/src/main/java/com/packit/api/domain/ai/dto/response/AiRecommendedCategoryResponse.java
@@ -1,0 +1,16 @@
+package com.packit.api.domain.ai.dto.response;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+@Schema(description = "AI 추천 응답: 카테고리별 아이템 목록")
+public record AiRecommendedCategoryResponse(
+        @Schema(description = "카테고리 이름", example = "의류") String category,
+        @Schema(description = "해당 카테고리에 포함된 추천 아이템 목록") List<AiRecommendedItemResponse> items
+) {
+    @Builder
+    public static AiRecommendedCategoryResponse from(String category, List<AiRecommendedItemResponse> items) {
+        return new AiRecommendedCategoryResponse(category, items);
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/ai/dto/response/AiRecommendedItemResponse.java
+++ b/api/src/main/java/com/packit/api/domain/ai/dto/response/AiRecommendedItemResponse.java
@@ -1,0 +1,15 @@
+package com.packit.api.domain.ai.dto.response;
+
+import com.packit.api.domain.ai.client.dto.AiRecommendApiResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "AI 추천 아이템 응답 DTO")
+public record AiRecommendedItemResponse(
+        @Schema(description = "추천된 항목 이름") String name,
+        @Schema(description = "수량") int quantity
+) {    @Builder
+    public static AiRecommendedItemResponse from(AiRecommendApiResponse apiResponse) {
+    return new AiRecommendedItemResponse(apiResponse.getName(), apiResponse.getQuantity());
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/ai/dto/response/AiRecommendedItemResponse.java
+++ b/api/src/main/java/com/packit/api/domain/ai/dto/response/AiRecommendedItemResponse.java
@@ -4,12 +4,13 @@ import com.packit.api.domain.ai.client.dto.AiRecommendApiResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
-@Schema(description = "AI 추천 아이템 응답 DTO")
+@Schema(description = "AI 추천 항목 응답 DTO")
 public record AiRecommendedItemResponse(
-        @Schema(description = "추천된 항목 이름") String name,
-        @Schema(description = "수량") int quantity
-) {    @Builder
-    public static AiRecommendedItemResponse from(AiRecommendApiResponse apiResponse) {
-    return new AiRecommendedItemResponse(apiResponse.getName(), apiResponse.getQuantity());
+        @Schema(description = "추천된 항목 이름", example = "속옷") String name,
+        @Schema(description = "수량", example = "3") int quantity
+) {
+    @Builder
+    public static AiRecommendedItemResponse from(AiRecommendApiResponse.AiRecommendItem item) {
+        return new AiRecommendedItemResponse(item.getName(), item.getQuantity());
     }
 }

--- a/api/src/main/java/com/packit/api/domain/ai/entity/AiRecommendationItemLog.java
+++ b/api/src/main/java/com/packit/api/domain/ai/entity/AiRecommendationItemLog.java
@@ -1,0 +1,35 @@
+package com.packit.api.domain.ai.entity;
+
+import com.packit.api.domain.tripCategory.entity.TripCategory;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class AiRecommendationItemLog {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private TripCategory tripCategory;
+
+    private String name;
+    private int quantity;
+
+    private LocalDateTime createdAt;
+
+    @Builder
+    public AiRecommendationItemLog(TripCategory tripCategory, String name, int quantity, LocalDateTime createdAt) {
+        this.tripCategory = tripCategory;
+        this.name = name;
+        this.quantity = quantity;
+        this.createdAt = createdAt;
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/ai/repository/AiRecommendationItemLogRepository.java
+++ b/api/src/main/java/com/packit/api/domain/ai/repository/AiRecommendationItemLogRepository.java
@@ -1,0 +1,12 @@
+package com.packit.api.domain.ai.repository;
+
+import com.packit.api.domain.ai.entity.AiRecommendationItemLog;
+import com.packit.api.domain.tripCategory.entity.TripCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AiRecommendationItemLogRepository extends JpaRepository<AiRecommendationItemLog, Long> {
+
+    List<AiRecommendationItemLog> findByTripCategory(TripCategory category);
+}

--- a/api/src/main/java/com/packit/api/domain/ai/service/AiRecommendService.java
+++ b/api/src/main/java/com/packit/api/domain/ai/service/AiRecommendService.java
@@ -1,0 +1,62 @@
+package com.packit.api.domain.ai.service;
+
+import com.packit.api.common.exception.NotFoundException;
+import com.packit.api.domain.ai.client.AiRecommendApiClient;
+import com.packit.api.domain.ai.client.dto.AiRecommendApiRequest;
+import com.packit.api.domain.ai.dto.request.AiRecommendRequest;
+import com.packit.api.domain.ai.dto.response.AiRecommendedItemResponse;
+import com.packit.api.domain.trip.entity.Trip;
+import com.packit.api.domain.trip.repository.TripRepository;
+import com.packit.api.domain.tripCategory.entity.TripCategory;
+import com.packit.api.domain.tripCategory.repository.TripCategoryRepository;
+import com.packit.api.domain.tripItem.entity.TripItem;
+import com.packit.api.domain.tripItem.repository.TripItemRepository;
+import com.packit.api.domain.user.entity.User;
+import com.packit.api.domain.user.exception.UserNotFoundException;
+import com.packit.api.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AiRecommendService {
+
+    private final AiRecommendApiClient aiRecommendApiClient; // FastAPI 연동
+    private final TripRepository tripRepository;
+    private final TripCategoryRepository tripCategoryRepository;
+    private final TripItemRepository tripItemRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public List<AiRecommendedItemResponse> recommendItems(Long userId, AiRecommendRequest request) {
+        Trip trip = tripRepository.findByIdAndUserId(request.tripId(), userId)
+                .orElseThrow(() -> new NotFoundException("여행을 찾을 수 없습니다."));
+
+        TripCategory category = tripCategoryRepository.findByIdAndTripId(request.tripCategoryId(), trip.getId())
+                .orElseThrow(() -> new NotFoundException("카테고리를 찾을 수 없습니다."));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("유저를 찾을 수 없습니다."));
+
+        // FastAPI 호출용 DTO 구성
+        AiRecommendApiRequest apiRequest = AiRecommendApiRequest.from(user, trip, category);
+
+        // FastAPI 호출
+        List<AiRecommendedItemResponse> response = aiRecommendApiClient.requestRecommendations(apiRequest);
+
+        // TripItem 저장
+        for (AiRecommendedItemResponse item : response) {
+            TripItem tripItem = TripItem.ofAiGenerated(
+                    category,
+                    item.name(),
+                    item.quantity()
+            );
+            tripItemRepository.save(tripItem);
+        }
+
+        return response;
+    }
+}

--- a/api/src/main/java/com/packit/api/domain/trip/controller/TripController.java
+++ b/api/src/main/java/com/packit/api/domain/trip/controller/TripController.java
@@ -51,7 +51,6 @@ public class TripController {
     }
 
     @Operation(summary = "여행 상세 조회", description = "여행 ID에 해당하는 상세 정보를 조회합니다.")
-
     @GetMapping("/{id}")
     public ResponseEntity<SingleResponse<TripResponse>> getTripDetail(
             @Parameter(name = "id", description = "조회할 여행 ID", required = true)

--- a/api/src/main/java/com/packit/api/domain/trip/dto/request/TripCreateRequest.java
+++ b/api/src/main/java/com/packit/api/domain/trip/dto/request/TripCreateRequest.java
@@ -4,6 +4,7 @@ import com.packit.api.domain.trip.entity.TripType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Schema(description = "여행 생성 요청 DTO")
 public record TripCreateRequest(
@@ -14,8 +15,8 @@ public record TripCreateRequest(
         @Schema(description = "여행 지역", example = "제주도")
         String region,
 
-        @Schema(description = "여행 유형 (FAMILY, FRIEND, BUSINESS, OTHER)", example = "FAMILY")
-        TripType tripType,
+        @Schema(description = "여행 유형 목록 (복수 선택 가능)", example = "[\"OVERSEAS\", \"SUMMER\"]")
+        List<TripType> tripTypes,
 
         @Schema(description = "여행 시작일 (yyyy-MM-dd)", example = "2025-07-01")
         LocalDate startDate,

--- a/api/src/main/java/com/packit/api/domain/trip/dto/request/TripUpdateRequest.java
+++ b/api/src/main/java/com/packit/api/domain/trip/dto/request/TripUpdateRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public record TripUpdateRequest(
         @NotBlank
@@ -18,7 +19,7 @@ public record TripUpdateRequest(
 
         @NotNull
         @Schema(description = "여행 유형 (FAMILY, FRIEND, BUSINESS, OTHER)", example = "FAMILY")
-        TripType tripType,
+        List<TripType> tripTypes,
 
         @NotNull
         @Schema(description = "수정된 여행 시작일 (yyyy-MM-dd)", example = "2025-07-02")

--- a/api/src/main/java/com/packit/api/domain/trip/dto/response/TripNearestResponse.java
+++ b/api/src/main/java/com/packit/api/domain/trip/dto/response/TripNearestResponse.java
@@ -5,6 +5,7 @@ import com.packit.api.domain.trip.entity.TripType;
 import lombok.Builder;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Builder
 public record TripNearestResponse(
@@ -14,7 +15,7 @@ public record TripNearestResponse(
         String description,
         LocalDate startDate,
         LocalDate endDate,
-        TripType tripType,
+        List<TripType> tripTypes,
         int progressRate
 ) {
     public static TripNearestResponse from(Trip trip, int totalCount, int checkedCount) {
@@ -26,7 +27,7 @@ public record TripNearestResponse(
                 .description(trip.getDescription())
                 .startDate(trip.getStartDate())
                 .endDate(trip.getEndDate())
-                .tripType(trip.getTripType())
+                .tripTypes(trip.getTripTypes())
                 .progressRate(progressRate)
                 .build();
     }

--- a/api/src/main/java/com/packit/api/domain/trip/dto/response/TripResponse.java
+++ b/api/src/main/java/com/packit/api/domain/trip/dto/response/TripResponse.java
@@ -4,12 +4,13 @@ import com.packit.api.domain.trip.entity.Trip;
 import com.packit.api.domain.trip.entity.TripType;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public record TripResponse(
         Long id,
         String title,
         String region,
-        TripType tripType,
+        List<TripType> tripTypes,
         LocalDate startDate,
         LocalDate endDate,
         String description,
@@ -20,7 +21,7 @@ public record TripResponse(
                 trip.getId(),
                 trip.getTitle(),
                 trip.getRegion(),
-                trip.getTripType(),
+                trip.getTripTypes(),
                 trip.getStartDate(),
                 trip.getEndDate(),
                 trip.getDescription(),

--- a/api/src/main/java/com/packit/api/domain/trip/entity/Trip.java
+++ b/api/src/main/java/com/packit/api/domain/trip/entity/Trip.java
@@ -30,8 +30,9 @@ public class Trip extends BaseTimeEntity {
     private String title;
     private String region;
 
+    @ElementCollection(fetch = FetchType.LAZY)
     @Enumerated(EnumType.STRING)
-    private TripType tripType;
+    private List<TripType> tripTypes= new ArrayList<>();
 
     private LocalDate startDate;
     private LocalDate endDate;
@@ -44,12 +45,12 @@ public class Trip extends BaseTimeEntity {
     private List<TripCategory> tripCategories = new ArrayList<>();
 
     @Builder
-    private Trip(User user, String title, String region, TripType tripType,
+    private Trip(User user, String title, String region, List<TripType> tripTypes,
                  LocalDate startDate, LocalDate endDate, String description) {
         this.user = user;
         this.title = title;
         this.region = region;
-        this.tripType = tripType;
+        this.tripTypes = tripTypes;
         this.startDate = startDate;
         this.endDate = endDate;
         this.description = description;
@@ -61,16 +62,17 @@ public class Trip extends BaseTimeEntity {
                 .user(user)
                 .title(request.title())
                 .region(request.region())
-                .tripType(request.tripType())
+                .tripTypes(request.tripTypes())
                 .startDate(request.startDate())
                 .endDate(request.endDate())
                 .description(request.description())
                 .build();
     }
+
     public void update(TripUpdateRequest request) {
         this.title = request.title();
         this.region = request.region();
-        this.tripType = request.tripType();
+        this.tripTypes = request.tripTypes();
         this.startDate = request.startDate();
         this.endDate = request.endDate();
         this.description = request.description();

--- a/api/src/main/java/com/packit/api/domain/trip/entity/TripType.java
+++ b/api/src/main/java/com/packit/api/domain/trip/entity/TripType.java
@@ -1,25 +1,51 @@
 package com.packit.api.domain.trip.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.stream.Stream;
+
 @Getter
 @RequiredArgsConstructor
-@Schema(description = "여행 유형 (FAMILY: 가족여행, FRIEND: 친구여행, BUSINESS: 출장, OTHER: 기타)")
+@Schema(description = "여행 유형 (각 항목은 사용자의 여행 상황이나 특성을 설명)")
 public enum TripType {
 
-    @Schema(description = "가족 여행")
-    FAMILY("가족"),
+    @Schema(description = "해외 여행")
+    OVERSEAS("해외"),
 
-    @Schema(description = "친구와의 여행")
-    FRIEND("친구"),
+    @Schema(description = "여름철 여행")
+    SUMMER("여름"),
 
-    @Schema(description = "출장")
-    BUSINESS("출장"),
+    @Schema(description = "겨울철 여행")
+    WINTER("겨울"),
 
-    @Schema(description = "기타")
-    OTHER("기타");
+    @Schema(description = "비 오는 날씨 여행")
+    RAINY("비오는날씨"),
+
+    @Schema(description = "생리 기간 중 여행")
+    MENSTRUAL_PERIOD("생리기간"),
+
+    @Schema(description = "아이 동반 여행")
+    WITH_CHILD("아이 동반"),
+
+    @Schema(description = "호텔 숙박 여행")
+    HOTEL("호텔 숙박");
 
     private final String displayName;
+
+    @JsonValue
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @JsonCreator
+    public static TripType from(String value) {
+        return Stream.of(TripType.values())
+                .filter(e -> e.displayName.equals(value) || e.name().equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 TripType: " + value));
+    }
 }

--- a/api/src/main/java/com/packit/api/domain/trip/repository/TripRepository.java
+++ b/api/src/main/java/com/packit/api/domain/trip/repository/TripRepository.java
@@ -1,6 +1,7 @@
 package com.packit.api.domain.trip.repository;
 
 import com.packit.api.domain.trip.entity.Trip;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,6 +19,8 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
     int countByUserIdAndIsCompletedTrue(Long userId);
 
     int countByUserIdAndIsCompletedFalse(Long userId);
+
+    Optional<Trip> findByIdAndUserId(Long tripId, Long userId);
 
     @Query("""
     SELECT t FROM Trip t

--- a/api/src/main/java/com/packit/api/domain/trip/service/TripService.java
+++ b/api/src/main/java/com/packit/api/domain/trip/service/TripService.java
@@ -1,6 +1,8 @@
 package com.packit.api.domain.trip.service;
 
 import com.packit.api.common.security.util.SecurityUtils;
+import com.packit.api.domain.ai.dto.request.AiRecommendRequest;
+import com.packit.api.domain.ai.service.AiRecommendService;
 import com.packit.api.domain.trip.dto.request.TripCreateRequest;
 import com.packit.api.domain.trip.dto.request.TripUpdateRequest;
 import com.packit.api.domain.trip.dto.response.*;
@@ -29,6 +31,7 @@ public class TripService {
     private final TripCategoryRepository tripCategoryRepository;
     private final TripItemRepository tripItemRepository;
     private final TripInitializerService tripInitializerService;
+    private final AiRecommendService aiRecommendService;
 
     @Transactional
     public TripResponse createTrip(TripCreateRequest request) {
@@ -40,6 +43,8 @@ public class TripService {
         Trip savedTrip = tripRepository.save(trip);
 
         tripInitializerService.initializeDefaultsFor(savedTrip);
+
+        aiRecommendService.recommendItems(userId, new AiRecommendRequest(savedTrip.getId()));
 
         return TripResponse.from(trip);
     }

--- a/api/src/main/java/com/packit/api/domain/tripCategory/repository/TripCategoryRepository.java
+++ b/api/src/main/java/com/packit/api/domain/tripCategory/repository/TripCategoryRepository.java
@@ -13,4 +13,6 @@ public interface TripCategoryRepository extends JpaRepository<TripCategory, Long
     List<TripCategory> findAllByTrip(Trip trip);
 
     Optional<TripCategory> findByIdAndTripId(Long tripCategoryId, Long tripId);
+
+    Optional<TripCategory> findByTripIdAndName(Long id, String categoryName);
 }

--- a/api/src/main/java/com/packit/api/domain/tripItem/entity/TripItem.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/entity/TripItem.java
@@ -69,6 +69,18 @@ public class TripItem extends BaseTimeEntity {
                 .build();
     }
 
+    public static TripItem ofAiGenerated(TripCategory tripCategory, String name, int quantity) {
+        return TripItem.builder()
+                .tripCategory(tripCategory)
+                .name(name)
+                .quantity(quantity)
+                .memo(null)
+                .isChecked(false)
+                .isSaved(true)
+                .isAiGenerated(true)
+                .build();
+    }
+
     public void toggleCheck() {
         this.isChecked = !this.isChecked;
     }

--- a/api/src/main/java/com/packit/api/domain/tripItem/service/TripItemService.java
+++ b/api/src/main/java/com/packit/api/domain/tripItem/service/TripItemService.java
@@ -165,6 +165,7 @@ public class TripItemService {
                 .toList();
 
         tripItemRepository.saveAll(tripItems);
+        updateCategoryStatusAfterItemChange(tripCategory);
     }
 
 }

--- a/api/src/main/resources/application-local.yml
+++ b/api/src/main/resources/application-local.yml
@@ -26,7 +26,7 @@ spring:
 
 ai:
     recommendation:
-        url: http://localhost:8000/ai/recommend
+        url: http://34.47.122.54/ai/recommend
 
 swagger:
     base-url: http://localhost:8080

--- a/api/src/main/resources/application-local.yml
+++ b/api/src/main/resources/application-local.yml
@@ -24,5 +24,9 @@ spring:
             port: 6379
             password: 1234
 
+ai:
+    recommendation:
+        url: http://localhost:8000/ai/recommend
+
 swagger:
     base-url: http://localhost:8080

--- a/api/src/main/resources/application-prod.yml
+++ b/api/src/main/resources/application-prod.yml
@@ -21,6 +21,8 @@ spring:
         redis:
             host: ${REDIS_HOST}
             port: ${REDIS_PORT}
-
+ai:
+    recommendation:
+        url: http://34.47.122.54/ai/recommend
 swagger:
     base-url: http://${SWAGGER_BASE_URL}


### PR DESCRIPTION

###  변경 내용
Packit 프로젝트에 Vertex AI 기반 짐 추천 기능을 완전 통합사용자의 TripCategory를 기반으로 AI가 추천하는 TripItem 리스트를 생성하며, 추천 결과는 TripItem으로 직접 저장되지 않고 별도 로그 테이블에 유지됩니다. 사용자는 선택적으로 확인할 수 있도록 구성하

---

###  주요 구현 내역
- Vertex AI Gemini 모델 연동 (`gemini-2.5-flash`)
- `AiRecommendationItemLog` 도메인 설계 및 테이블 생성
  - TripCategory 기준으로 AI 추천 결과 저장
- `/recommendVertex` API (POST)
  - 여행 정보 + TripCategory ID 입력 시 AI 추천 결과 반환 및 저장
- `/recommendVertex/logs` API (GET)
  - 특정 TripCategory의 AI 추천 로그 목록 조회
- FastAPI → Spring API 통합 구조 완성
